### PR TITLE
Feat: Create a new /api/subscribe endpoint, create a subscribe controller to successfully sending welcome email to user

### DIFF
--- a/.github/workflows/ci-tests-and-code-style.yml
+++ b/.github/workflows/ci-tests-and-code-style.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     env:
       AUTH_EMAIL: ${{ secrets.AUTH_EMAIL }}

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -3,10 +3,10 @@ module.exports = {
     [
       "@babel/preset-env",
       {
-        targets: {
-          node: "current",
-        },
+        targets: { node: "current" },
+        modules: "auto",
       },
     ],
   ],
+  plugins: ["babel-plugin-transform-import-meta"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@babel/core": "^7.24.7",
         "@babel/preset-env": "^7.24.7",
         "babel-jest": "^27.5.1",
+        "babel-plugin-transform-import-meta": "^2.3.2",
         "eslint": "^8.2.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.3.0",
@@ -4790,6 +4791,19 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-transform-import-meta": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-import-meta/-/babel-plugin-transform-import-meta-2.3.2.tgz",
+      "integrity": "sha512-902o4GiQqI1GqAXfD5rEoz0PJamUfJ3VllpdWaNsFTwdaNjFSFHawvBO+cp5K2j+g2h3bZ4lnM1Xb6yFYGihtA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.25.9",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.10.0"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/core": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
     "babel-jest": "^27.5.1",
+    "babel-plugin-transform-import-meta": "^2.3.2",
     "eslint": "^8.2.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.3.0",

--- a/src/__tests__/controllerTest/subscribeControllerTest/subscribeController.test.js
+++ b/src/__tests__/controllerTest/subscribeControllerTest/subscribeController.test.js
@@ -102,6 +102,7 @@ describe("subscribeUser", () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
+      success: true,
       message: "Subscription successful! Check your email for confirmation.",
     });
   });
@@ -118,7 +119,9 @@ describe("subscribeUser", () => {
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({
-      error: "Failed to send confirmation email",
+      success: false,
+      message: "Failed to send confirmation email",
+      error: "Failed to send email",
     });
   });
 });

--- a/src/__tests__/controllerTest/subscribeControllerTest/subscribeController.test.js
+++ b/src/__tests__/controllerTest/subscribeControllerTest/subscribeController.test.js
@@ -1,0 +1,125 @@
+import { subscribeUser } from "../../../controllers/subscribeControllers/subscribeController";
+import nodemailer from "nodemailer";
+import fs from "fs";
+import path from "path";
+
+jest.mock("nodemailer");
+jest.mock("fs");
+jest.mock("path");
+
+describe("subscribeUser", () => {
+  let req, res;
+
+  beforeEach(() => {
+    req = {
+      body: {
+        email: "test@example.com",
+      },
+    };
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    process.env.MAIL_HOST = "smtp.example.com";
+    process.env.MAIL_PORT = "587";
+    process.env.MAIL_SECURE = "false";
+    process.env.AUTH_EMAIL = "test@example.com";
+    process.env.AUTH_PASSWORD = "password";
+
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue("<html>Welcome {{EMAIL}}</html>");
+
+
+    path.resolve.mockImplementation((...args) => args.join("/"));
+    path.dirname.mockReturnValue("/mock/dir");
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return 400 if email is missing", () => {
+    req.body.email = "";
+
+    subscribeUser(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "Email is required" });
+  });
+
+  it("should return 500 if the welcome email template is not found", () => {
+    fs.existsSync.mockReturnValue(false);
+
+    subscribeUser(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Internal server error: Template not found",
+    });
+  });
+
+  it("should return 500 if there is an error reading the welcome email template", () => {
+    fs.readFileSync.mockImplementation(() => {
+      throw new Error("File read error");
+    });
+
+    subscribeUser(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Internal server error",
+    });
+  });
+
+  it("should send a confirmation email and return 200 on success", () => {
+    const sendMailMock = jest.fn((mailOptions, callback) => callback(null));
+    nodemailer.createTransport.mockReturnValue({
+      sendMail: sendMailMock,
+    });
+
+    subscribeUser(req, res);
+
+    expect(nodemailer.createTransport).toHaveBeenCalledWith({
+      host: "smtp.example.com",
+      port: "587",
+      secure: false,
+      auth: {
+        user: "test@example.com",
+        pass: "password",
+      },
+    });
+
+    expect(sendMailMock).toHaveBeenCalledWith(
+      {
+        from: "test@example.com",
+        to: "test@example.com",
+        subject: "Subscription Confirmation",
+        html: "<html>Welcome test@example.com</html>",
+      },
+      expect.any(Function),
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Subscription successful! Check your email for confirmation.",
+    });
+  });
+
+  it("should return 500 if there is an error sending the email", () => {
+    const sendMailMock = jest.fn((mailOptions, callback) =>
+      callback(new Error("Failed to send email")),
+    );
+    nodemailer.createTransport.mockReturnValue({
+      sendMail: sendMailMock,
+    });
+
+    subscribeUser(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      error: "Failed to send confirmation email",
+    });
+  });
+});

--- a/src/__tests__/controllerTest/subscribeControllerTest/subscribeController.test.js
+++ b/src/__tests__/controllerTest/subscribeControllerTest/subscribeController.test.js
@@ -31,7 +31,6 @@ describe("subscribeUser", () => {
     fs.existsSync.mockReturnValue(true);
     fs.readFileSync.mockReturnValue("<html>Welcome {{EMAIL}}</html>");
 
-
     path.resolve.mockImplementation((...args) => args.join("/"));
     path.dirname.mockReturnValue("/mock/dir");
   });

--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import { requireAuth } from "./middleware/authMiddleware.js";
 import userRouter from "./routes/userRoutes.js";
 import authRouter from "./routes/authRoutes.js";
 import reviewRouter from "./routes/reviewRoutes.js";
+import subscribeRouter from "./routes/subscribeRoutes.js";
 
 dotenv.config();
 
@@ -46,5 +47,6 @@ app.use(
 app.use("/api/auth", authRouter);
 app.use("/api/user", requireAuth, userRouter);
 app.use("/api/reviews", reviewRouter);
+app.use("/api/subscribe", subscribeRouter);
 
 export default app;

--- a/src/controllers/subscribeControllers/subscribeController.js
+++ b/src/controllers/subscribeControllers/subscribeController.js
@@ -1,0 +1,76 @@
+import nodemailer from "nodemailer";
+import dotenv from "dotenv";
+import fs from "fs";
+import path from "path";
+
+dotenv.config();
+
+const transporter = nodemailer.createTransport({
+  host: process.env.MAIL_HOST,
+  port: process.env.MAIL_PORT,
+  secure: process.env.MAIL_SECURE === "true",
+  auth: {
+    user: process.env.AUTH_EMAIL,
+    pass: process.env.AUTH_PASSWORD,
+  },
+});
+
+const resolvePath = (relativePath) => {
+  const basePath = new URL(".", import.meta.url).pathname;
+  return path.resolve(basePath, relativePath);
+};
+
+const subscribeUser = (req, res) => {
+  const { email } = req.body;
+
+  if (!email) {
+    return res.status(400).json({ error: "Email is required" });
+  }
+
+  const welcomeTemplatePath = resolvePath(
+    "../../templates/emailWelcomeTemplate.html",
+  );
+
+  if (!fs.existsSync(welcomeTemplatePath)) {
+    console.error(
+      `Welcome email template not found at: ${welcomeTemplatePath}`,
+    );
+    return res.status(500).json({
+      error: "Internal server error: Template not found",
+    });
+  }
+
+  let welcomeEmailTemplate;
+  try {
+    welcomeEmailTemplate = fs.readFileSync(welcomeTemplatePath, "utf-8");
+  } catch (error) {
+    console.error(`Error reading welcome email template: ${error.message}`);
+    return res.status(500).json({
+      error: "Internal server error",
+    });
+  }
+
+  welcomeEmailTemplate = welcomeEmailTemplate.replace("{{EMAIL}}", email);
+
+  const mailOptions = {
+    from: process.env.AUTH_EMAIL,
+    to: email,
+    subject: "Subscription Confirmation",
+    html: welcomeEmailTemplate,
+  };
+
+  transporter.sendMail(mailOptions, (error, info) => {
+    if (error) {
+      console.error("Error sending email:", error);
+      return res
+        .status(500)
+        .json({ error: "Failed to send confirmation email" });
+    }
+
+    res.status(200).json({
+      message: "Subscription successful! Check your email for confirmation.",
+    });
+  });
+};
+
+export { subscribeUser };

--- a/src/controllers/subscribeControllers/subscribeController.js
+++ b/src/controllers/subscribeControllers/subscribeController.js
@@ -2,22 +2,13 @@ import nodemailer from "nodemailer";
 import dotenv from "dotenv";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 
 dotenv.config();
 
-const transporter = nodemailer.createTransport({
-  host: process.env.MAIL_HOST,
-  port: process.env.MAIL_PORT,
-  secure: process.env.MAIL_SECURE === "true",
-  auth: {
-    user: process.env.AUTH_EMAIL,
-    pass: process.env.AUTH_PASSWORD,
-  },
-});
-
 const resolvePath = (relativePath) => {
-  const basePath = new URL(".", import.meta.url).pathname;
-  return path.resolve(basePath, relativePath);
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(__dirname, relativePath);
 };
 
 const subscribeUser = (req, res) => {
@@ -52,6 +43,16 @@ const subscribeUser = (req, res) => {
 
   welcomeEmailTemplate = welcomeEmailTemplate.replace("{{EMAIL}}", email);
 
+  const transporter = nodemailer.createTransport({
+    host: process.env.MAIL_HOST,
+    port: process.env.MAIL_PORT,
+    secure: process.env.MAIL_SECURE === "true",
+    auth: {
+      user: process.env.AUTH_EMAIL,
+      pass: process.env.AUTH_PASSWORD,
+    },
+  });
+
   const mailOptions = {
     from: process.env.AUTH_EMAIL,
     to: email,
@@ -59,7 +60,7 @@ const subscribeUser = (req, res) => {
     html: welcomeEmailTemplate,
   };
 
-  transporter.sendMail(mailOptions, (error, info) => {
+  transporter.sendMail(mailOptions, (error) => {
     if (error) {
       console.error("Error sending email:", error);
       return res

--- a/src/controllers/subscribeControllers/subscribeController.js
+++ b/src/controllers/subscribeControllers/subscribeController.js
@@ -63,12 +63,15 @@ const subscribeUser = (req, res) => {
   transporter.sendMail(mailOptions, (error) => {
     if (error) {
       console.error("Error sending email:", error);
-      return res
-        .status(500)
-        .json({ error: "Failed to send confirmation email" });
+      return res.status(500).json({
+        success: false,
+        message: "Failed to send confirmation email",
+        error: error.message || "Failed to send confirmation email",
+      });
     }
 
     res.status(200).json({
+      success: true,
       message: "Subscription successful! Check your email for confirmation.",
     });
   });

--- a/src/routes/subscribeRoutes.js
+++ b/src/routes/subscribeRoutes.js
@@ -1,0 +1,8 @@
+import express from "express";
+import { subscribeUser } from "../controllers/subscribeControllers/subscribeController.js";
+
+const subscribeRouter = express.Router();
+
+subscribeRouter.post("/", subscribeUser);
+
+export default subscribeRouter;

--- a/src/templates/emailWelcomeTemplate.html
+++ b/src/templates/emailWelcomeTemplate.html
@@ -85,7 +85,7 @@
     <div class="container">
       <div class="header">
         <img
-          src="/src/public/images/donna-vino-logo-transparent.png"
+          src="https://donna-vino-aps-corporate-03ca98a66972.herokuapp.com/images/donna-vino-logo-transparent.png"
           alt="Avatar"
         />
 
@@ -106,16 +106,28 @@
 
       <div class="content">
         <spam>Let's raise a glass to new beginnings!</spam>
-        <img class="wine-glasses" src="/src/public/icons/wine-glasses.png" />
+        <img
+          class="wine-glasses"
+          src="https://donna-vino-aps-corporate-03ca98a66972.herokuapp.com/icons/wine-glasses.png"
+        />
 
         <p>Thank you,<br />The Donna Vino Team</p>
       </div>
 
       <div class="footer">
         <p>Want updates through more platforms?</p>
-        <img src="/src/public/icons/facebook-line.svg" alt="facebook" />
-        <img src="/src/public/icons/instagram-original.svg" alt="instagram" />
-        <img src="/src/public/icons/linkedin-alt.svg" alt="linkedin" />
+        <img
+          src="https://donna-vino-aps-corporate-03ca98a66972.herokuapp.com/icons/facebook-line.svg"
+          alt="facebook"
+        />
+        <img
+          src="https://donna-vino-aps-corporate-03ca98a66972.herokuapp.com/icons/instagram-original.svg"
+          alt="instagram"
+        />
+        <img
+          src="https://donna-vino-aps-corporate-03ca98a66972.herokuapp.com/icons/linkedin-alt.svg"
+          alt="linkedin"
+        />
         <p>Wildersgade 23, 1408 København K</p>
         <p>
           <a href="#">Unsubscribe</a> | <a href="#">Privacy policy</a> |


### PR DESCRIPTION
### New Features:
- Created a new `/api/subscribe` route for handling subscriptions.
- Implemented email sending functionality using Nodemailer to send a welcome email.
- Updated paths for images and icons to use the published frontend path.
- Added `babel-plugin-transform-import-meta` to enable `import.meta.url` support.
- Added tests for the `subscribeController.js`.

### How to test?
Send a post request to `/api/subscribe` with a real email in the body, for example:
`{"email": "your-own-email@gmail.com"}`


### Things to Check (Reviewers Please take a look at this !!!!)

1. **Welcome Template Spam Issue**:  
   - The content in the `emailWelcomeTemplate.html` might be marked as spam by email providers (e.g., Gmail). MAybe because of certain phrases, links, or formatting issues. It's nice if someone (maybe content creator) modify the email template contents later.

2. **Icons/Images Path in Template**:  
   - The paths for icons and images in `emailWelcomeTemplate.html`. Currently, the template uses the public URL:  
     `https://donna-vino-aps-corporate-03ca98a66972.herokuapp.com/`  
   - Ensure this URL is the correct and released one, as it might not be the intended or permanent URL for the images in the production environment.
   
### Screenshot of the email I received
![image](https://github.com/user-attachments/assets/c31eab58-3309-432e-a9d1-47b1d5dd3498)


