### PR TITLE
Fix Google sign-in token handling and globals for tests

### DIFF
--- a/src/controllers/authControllers/emailWelcomeController.js
+++ b/src/controllers/authControllers/emailWelcomeController.js
@@ -2,6 +2,7 @@ import bcrypt from "bcrypt";
 import { v4 as uuidv4 } from "uuid";
 import fs from "fs";
 import path from "path";
+import { __dirname } from "../../util/globals.js";
 import { createTransporter } from "../../config/emailConfig.js";
 import UserVerification from "../../models/userVerification.js";
 import { logError, logInfo } from "../../util/logging.js";
@@ -34,7 +35,7 @@ export const sendWelcomeEmail = async (user) => {
 
     logInfo("Step 2: Reading email template...");
     const welcomeTemplatePath = resolvePath(
-      "../../templates/emailWelcomeTemplate.html",
+      "../templates/emailWelcomeTemplate.html",
     );
     const welcomeEmailTemplate = readTemplate(welcomeTemplatePath);
 

--- a/src/controllers/authControllers/signInWithGoogleController.js
+++ b/src/controllers/authControllers/signInWithGoogleController.js
@@ -49,10 +49,13 @@ export const signInWithGoogleController = async (req, res) => {
       }
     }
 
-    const { token, email, name, picture } = req.body;
+    // CHANGE: Use id_token (JWT) instead of token.
+    // This is the token returned by Google when "openid" scope is requested.
+    const { id_token, email, name, picture } = req.body;
 
     let user;
-    if (!token) {
+    if (!id_token) {
+      // CHANGE: Check for id_token here instead of token
       if (!email || !name || !picture) {
         return res.status(401).json({ error: "Missing user data" });
       }
@@ -71,8 +74,9 @@ export const signInWithGoogleController = async (req, res) => {
         logInfo(`New Web user created: ${user.email}`);
       }
     } else {
+      // CHANGE: Use id_token in verifyIdToken
       const ticket = await client.verifyIdToken({
-        idToken: token,
+        idToken: id_token, // CHANGE: Using id_token here
         audience: process.env.GOOGLE_CLIENT_ID_WEB,
       });
 

--- a/src/util/globals.js
+++ b/src/util/globals.js
@@ -1,0 +1,13 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+// For Jest tests, we don't have import.meta.url working as expected,
+// so we use process.cwd() to set __dirname assuming this file is in "src/util".
+// Otherwise, use the normal method to get __dirname from the module URL.
+export const __filename = process.env.JEST_WORKER_ID
+  ? ""
+  : fileURLToPath(import.meta.url);
+
+export const __dirname = process.env.JEST_WORKER_ID
+  ? path.join(process.cwd(), "src", "util")
+  : path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
- Updated signInWithGoogleController to destructure and use "id_token" (JWT) instead of "token" for proper verification.
- Modified verifyIdToken call to pass "id_token", ensuring the correct token is validated.
- Created/updated globals.js to define __filename and __dirname conditionally for Jest (using process.cwd() when testing) so that file paths resolve correctly in tests.
- Adjusted template file path resolution in emailWelcomeController to match expected paths in the test environment.
- Here we can see that i received the email
![image](https://github.com/user-attachments/assets/31d3fe8d-ef48-4d44-a1d2-9446d8d9be62)
- All the steps works correctly
![image](https://github.com/user-attachments/assets/c7210994-4630-4e42-9601-764449dc88e9)
