### PR TITLE
fix: signInWithGoogleController.vitest.js

### DIFF
--- a/src/vitest-tests/controllers/signInWithGoogleController.vitest.js
+++ b/src/vitest-tests/controllers/signInWithGoogleController.vitest.js
@@ -27,6 +27,11 @@ vi.mock("../../controllers/authControllers/emailWelcomeController.js", () => ({
   sendWelcomeEmail: vi.fn(),
 }));
 
+vi.mock("../../util/logging.js", () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
 beforeAll(async () => {
   await connectToMockDB();
 });
@@ -41,120 +46,15 @@ afterAll(async () => {
 });
 
 describe("signInWithGoogleController", () => {
-  it("Should sign in successfully and create a new user if not exists", async () => {
+  it("should sign in a new user and send a welcome email", async () => {
     const userData = {
-      firstName: "John",
-      lastName: "Doe",
-      email: "john@example.com",
-      picture: "http://example.com/john.jpg",
-    };
-
-    sendWelcomeEmail.mockResolvedValue(true);
-
-    const response = await request
-      .post("/api/auth/sign-in-with-google")
-      .send(userData);
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
-    expect(response.body.msg).toBe("User signed in successfully");
-    expect(response.body.token).toBeDefined();
-    expect(sendWelcomeEmail).toHaveBeenCalledTimes(1);
-
-    // Verify that the response contains the correct user details
-    expect(response.body.user.firstName).toBe(userData.firstName);
-    expect(response.body.user.lastName).toBe(userData.lastName);
-    expect(response.body.user.email).toBe(userData.email);
-    expect(response.body.user.picture).toBe(userData.picture);
-
-    const user = await User.findOne({ email: userData.email });
-    expect(user).toBeDefined();
-  });
-
-  it("Should sign in an existing user without creating a new one", async () => {
-    const existingUser = new User({
-      firstName: "Jane",
-      lastName: "Doe",
-      email: "jane@example.com",
-      picture: "http://example.com/jane.jpg",
-      password: "hashedpassword",
-      authProvider: "google",
-    });
-
-    await existingUser.save();
-
-    sendWelcomeEmail.mockResolvedValue(true);
-
-    const response = await request.post("/api/auth/sign-in-with-google").send({
-      firstName: "Jane",
-      lastName: "Doe",
-      email: "jane@example.com",
-      picture: "http://example.com/jane.jpg",
-    });
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
-    expect(response.body.msg).toBe("User signed in successfully");
-    expect(response.body.token).toBeDefined();
-    expect(sendWelcomeEmail).not.toHaveBeenCalled();
-  });
-
-  it("Should verify an existing session and return user data", async () => {
-    const user = new User({
-      firstName: "Alice",
-      lastName: "Smith",
-      email: "alice@example.com",
-      picture: "http://example.com/alice.jpg",
-      password: "hashedpassword",
-      authProvider: "google",
-    });
-
-    await user.save();
-
-    const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
-      expiresIn: "72h",
-    });
-
-    const response = await request
-      .post("/api/auth/sign-in-with-google")
-      .set("Cookie", `session=${token}`)
-      .send({});
-
-    expect(response.status).toBe(200);
-    expect(response.body.success).toBe(true);
-    expect(response.body.msg).toBe("User is already signed in");
-    expect(response.body.user.email).toBe(user.email);
-    expect(response.body.user.firstName).toBe(user.firstName);
-    expect(response.body.user.lastName).toBe(user.lastName);
-  });
-
-  it("Should return error if token verification fails", async () => {
-    vi.spyOn(jwt, "verify").mockImplementation(() => {
-      throw new Error("Missing user data");
-    });
-
-    const response = await request
-      .post("/api/auth/sign-in-with-google")
-      .set("Cookie", "session=invalidToken")
-      .send({});
-
-    expect(response.status).toBe(401);
-    expect(response.body.error).toBe("Missing user data");
-  });
-
-  it("Should sign in successfully with a valid Google token", async () => {
-    const userData = {
-      firstName: "Bob",
-      lastName: "Brown",
-      email: "bob@example.com",
-      picture: "http://example.com/bob.jpg",
-      token: "mockGoogleIdToken",
+      id_token: "mockGoogleIdToken",
     };
 
     const mockPayload = {
-      name: "Bob Brown",
-      email: "bob@example.com",
-      picture: "http://example.com/bob.jpg",
+      name: "John Doe",
+      email: "john@example.com",
+      picture: "http://example.com/john.jpg",
     };
 
     vi.spyOn(OAuth2Client.prototype, "verifyIdToken").mockResolvedValue({
@@ -169,15 +69,94 @@ describe("signInWithGoogleController", () => {
 
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
+    expect(response.body.msg).toBe("User signed in successfully");
     expect(response.body.token).toBeDefined();
-    expect(response.body.user.email).toBe(userData.email);
-    // Since the controller splits the name from the Google payload,
-    // we expect firstName and lastName to be "Bob" and "Brown" respectively.
-    expect(response.body.user.firstName).toBe("Bob");
-    expect(response.body.user.lastName).toBe("Brown");
+    expect(response.body.user.email).toBe(mockPayload.email);
+    expect(response.body.user.firstName).toBe("John");
+    expect(response.body.user.lastName).toBe("Doe");
     expect(sendWelcomeEmail).toHaveBeenCalledTimes(1);
 
-    const user = await User.findOne({ email: userData.email });
+    const user = await User.findOne({ email: mockPayload.email });
     expect(user).toBeDefined();
+  });
+
+  it("should return existing user without sending welcome email", async () => {
+    const existingUser = new User({
+      firstName: "Jane",
+      lastName: "Doe",
+      email: "jane@example.com",
+      picture: "http://example.com/jane.jpg",
+      authProvider: "google",
+    });
+
+    await existingUser.save();
+
+    const mockPayload = {
+      name: "Jane Doe",
+      email: "jane@example.com",
+      picture: "http://example.com/jane.jpg",
+    };
+
+    vi.spyOn(OAuth2Client.prototype, "verifyIdToken").mockResolvedValue({
+      getPayload: () => mockPayload,
+    });
+
+    const response = await request
+      .post("/api/auth/sign-in-with-google")
+      .send({ id_token: "mockGoogleIdToken" });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.user.email).toBe(existingUser.email);
+    expect(sendWelcomeEmail).not.toHaveBeenCalled();
+  });
+
+  it("should return current session user if session is valid", async () => {
+    const user = new User({
+      firstName: "Alice",
+      lastName: "Smith",
+      email: "alice@example.com",
+      picture: "http://example.com/alice.jpg",
+      authProvider: "google",
+    });
+
+    await user.save();
+
+    const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
+      expiresIn: "72h",
+    });
+
+    const response = await request
+      .post("/api/auth/sign-in-with-google")
+      .set("Cookie", `session=${token}`)
+      .send();
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.msg).toBe("User is already signed in");
+    expect(response.body.user.email).toBe(user.email);
+  });
+
+  it("should return error if token verification fails", async () => {
+    vi.spyOn(jwt, "verify").mockImplementation(() => {
+      throw new Error("Invalid token");
+    });
+
+    const response = await request
+      .post("/api/auth/sign-in-with-google")
+      .set("Cookie", "session=invalidToken")
+      .send();
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("Missing user data");
+  });
+
+  it("should handle missing user data error", async () => {
+    const response = await request
+      .post("/api/auth/sign-in-with-google")
+      .send({});
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe("Missing user data");
   });
 });

--- a/src/vitest-tests/controllers/userController.vitest.js
+++ b/src/vitest-tests/controllers/userController.vitest.js
@@ -44,7 +44,6 @@ describe("getUsers Controller", () => {
       },
     ];
 
-    // Register the users using the updated payload.
     await Promise.all(
       users.map(async (user) => {
         await request.post("/api/auth/sign-up").send({ user });
@@ -56,15 +55,14 @@ describe("getUsers Controller", () => {
       password: "Password1!",
     };
 
-    // Log in the first user and get the session cookie.
     const loginResponse = await request
       .post("/api/auth/log-in")
       .send({ user: loginUser });
+
     expect(loginResponse.status).toBe(200);
 
     const sessionCookie = loginResponse.headers["set-cookie"][0];
 
-    // Request the list of users with the valid session cookie.
     const response = await request
       .get("/api/user/")
       .set("Cookie", sessionCookie);
@@ -101,7 +99,6 @@ describe("getUsers Controller", () => {
       },
     ];
 
-    // Register the users.
     await Promise.all(
       users.map(async (user) => {
         await request.post("/api/auth/sign-up").send({ user });
@@ -113,15 +110,14 @@ describe("getUsers Controller", () => {
       password: "Password1!",
     };
 
-    // Log in the first user and get the valid session cookie.
     const loginResponse = await request
       .post("/api/auth/log-in")
       .send({ user: loginUser });
+
     expect(loginResponse.status).toBe(200);
 
     const validSessionCookie = loginResponse.headers["set-cookie"][0];
 
-    // Modify the session cookie to simulate a token mismatch.
     const modifiedSessionCookie = validSessionCookie.replace(
       /session=[^;]*/,
       "session=invalid_session_token",
@@ -168,11 +164,11 @@ describe("getUsers Controller", () => {
     const loginResponse = await request
       .post("/api/auth/log-in")
       .send({ user: loginUser });
+
     expect(loginResponse.status).toBe(200);
 
     const validSessionCookie = loginResponse.headers["set-cookie"][0];
 
-    // Modify the session cookie to simulate missing/invalid userId.
     const modifiedSessionCookie = validSessionCookie.replace(
       /session=[^;]*/,
       "session=invalid_userId_token",


### PR DESCRIPTION
Fixed the errors in the **signInWithGoogle** and **user** controller tests.  

In my previous branch, I had conflicts in these two files. I proceeded to pull and resolve them, but there were no conflicts in the tests, so I didn’t update them because I hadn’t worked on those files. For the sake of speed and to prevent issues with the environment variables for the rest of the team, I performed a quick merge.  

What I find strange is that the tests were passing locally, but they are failing here, which makes me think there might be something to improve in the **Vitest** integration. For now, the issue is resolved.