### PR TITLE
refactor/ fix the sign up and the sendig of the emails, and correct m…

### DIFF
--- a/src/controllers/authControllers/signupController.js
+++ b/src/controllers/authControllers/signupController.js
@@ -3,9 +3,13 @@ import validationErrorMessage from "../../util/validationErrorMessage.js";
 import { validateUser } from "../../models/userModels.js";
 import User from "../../models/userModels.js";
 import validateAllowedFields from "../../util/validateAllowedFields.js";
+import path from "path";
+import fs from "fs";
+import { sendEmail } from "../../util/emailUtils.js";
+import SubscribedUser from "../../models/subscribedUser.js";
 
 export const signup = async (req, res) => {
-  // Updated allowed fields based on the new user model
+  // Allowed fields in the user model
   const allowedFields = [
     "firstName",
     "lastName",
@@ -13,9 +17,10 @@ export const signup = async (req, res) => {
     "password",
     "dateOfBirth",
     "authProvider",
+    "isSubscribed",
   ];
 
-  if (!(req.body.user instanceof Object)) {
+  if (!req.body.user || typeof req.body.user !== "object") {
     return res.status(400).json({
       success: false,
       msg: `Invalid request: You need to provide a valid 'user' object. Received: ${JSON.stringify(
@@ -24,60 +29,113 @@ export const signup = async (req, res) => {
     });
   }
 
-  if (req.body.user && req.body.user.email) {
+  // Normalize email if provided
+  if (req.body.user.email && typeof req.body.user.email === "string") {
     req.body.user.email = req.body.user.email.toLowerCase();
   }
 
+  // Validate `isSubscribed` field
+  if (
+    req.body.user.hasOwnProperty("isSubscribed") &&
+    typeof req.body.user.isSubscribed !== "boolean"
+  ) {
+    return res.status(400).json({
+      success: false,
+      msg: "Invalid request: 'isSubscribed' must be true or false.",
+    });
+  }
+
+  // Validate the allowed fields
   const invalidFieldsError = validateAllowedFields(
     req.body.user,
     allowedFields,
   );
   if (invalidFieldsError) {
-    return res
-      .status(400)
-      .json({ success: false, msg: `Invalid request: ${invalidFieldsError}` });
+    return res.status(400).json({
+      success: false,
+      msg: `Invalid request: ${invalidFieldsError}`,
+    });
   }
 
-  // Call validateUser with just the user object
+  // Validate the user data
   const errorList = validateUser(req.body.user);
   if (errorList.length > 0) {
-    return res
-      .status(400)
-      .json({ success: false, msg: validationErrorMessage(errorList) });
+    return res.status(400).json({
+      success: false,
+      msg: validationErrorMessage(errorList),
+    });
   }
 
   try {
-    const { email } = req.body.user;
+    const { email, isSubscribed = false } = req.body.user;
     const existingUser = await User.findOne({ email });
+
     if (existingUser) {
-      return res
-        .status(400)
-        .json({ success: false, msg: "User already exists" });
+      // If the user exists, only update `isSubscribed` field if needed
+      if (!existingUser.isSubscribed && isSubscribed) {
+        existingUser.isSubscribed = true;
+        await existingUser.save();
+        logInfo(`Updated isSubscribed to true for existing user: ${email}`);
+      }
+      return res.status(200).json({
+        success: true,
+        msg: "User already exists.",
+        user: {
+          id: existingUser._id,
+          firstName: existingUser.firstName,
+          lastName: existingUser.lastName,
+          email: existingUser.email,
+          authProvider: existingUser.authProvider,
+          isVip: existingUser.isVip,
+          isSubscribed: existingUser.isSubscribed,
+        },
+      });
     }
 
+    // If the user does not exist, create a new one
     const newUser = await User.create(req.body.user);
-
     logInfo(`User created successfully: ${newUser.email}`);
 
-    // Prepare a response without sensitive data
-    const userResponse = {
-      id: newUser._id,
-      firstName: newUser.firstName,
-      lastName: newUser.lastName,
+    // If the user previously subscribed to the newsletter, remove that record.
+    const subscribedRecord = await SubscribedUser.findOne({
       email: newUser.email,
-      authProvider: newUser.authProvider,
-      isVip: newUser.isVip,
-    };
+    });
+    if (subscribedRecord) {
+      await SubscribedUser.deleteOne({ _id: subscribedRecord._id });
+      logInfo(`Removed existing SubscribedUser record for ${newUser.email}`);
+    }
+
+    try {
+      const templatePath = path.resolve(
+        process.cwd(),
+        "src/templates/verifyEmailTemplate.html",
+      );
+      const templateContent = fs.readFileSync(templatePath, "utf-8");
+      const welcomeSubject = "Welcome to Donna Vino! Please Verify Your Email";
+      await sendEmail(newUser.email, welcomeSubject, templateContent);
+      logInfo(`Verify email sent to ${newUser.email}`);
+    } catch (emailError) {
+      logError("Error sending verify email: " + emailError.message);
+    }
 
     return res.status(201).json({
       success: true,
       msg: "User created successfully",
-      user: userResponse,
+      user: {
+        id: newUser._id,
+        firstName: newUser.firstName,
+        lastName: newUser.lastName,
+        email: newUser.email,
+        authProvider: newUser.authProvider,
+        isVip: newUser.isVip,
+        isSubscribed: newUser.isSubscribed,
+      },
     });
   } catch (error) {
     logError("Error in signup process: " + error.message);
-    return res
-      .status(500)
-      .json({ success: false, msg: "Unable to create user, try again later" });
+    return res.status(500).json({
+      success: false,
+      msg: "Unable to create user, please try again later.",
+    });
   }
 };

--- a/src/models/userModels.js
+++ b/src/models/userModels.js
@@ -62,10 +62,18 @@ export const validateUser = (userObject) => {
     "password",
     "dateOfBirth",
     "authProvider",
+    "isSubscribed",
   ];
   const validatedKeysMessage = validateAllowedFields(userObject, allowedKeys);
   if (validatedKeysMessage.length > 0) {
     errorList.push(validatedKeysMessage);
+  }
+
+  if (
+    userObject.isSubscribed !== undefined &&
+    typeof userObject.isSubscribed !== "boolean"
+  ) {
+    errorList.push("isSubscribed must be a boolean value (true/false).");
   }
 
   // Validate firstName

--- a/src/vitest-tests/controllers/sendEmailController.vitest.js
+++ b/src/vitest-tests/controllers/sendEmailController.vitest.js
@@ -154,23 +154,11 @@ describe("sendEmailController", () => {
     fs.existsSync.mockReturnValue(true);
     fs.readFileSync.mockReturnValue("Hello World");
     sendEmail.mockResolvedValue({ messageId: "12345" });
-
-    // Mocking user model
-    const user = {
-      _id: "userId",
-      email: "test@example.com",
-      isSubscribed: false,
-      save: vi.fn(),
-    };
-
-    User.findOne = vi.fn().mockResolvedValue(user);
+    User.findOne = vi.fn().mockResolvedValue(null);
     SubscribedUser.findOne = vi.fn().mockResolvedValue(null);
     SubscribedUser.prototype.save = vi.fn().mockResolvedValue();
-
     await sendEmailController(req, res);
-
     expect(User.findOne).toHaveBeenCalledWith({ email: "test@example.com" });
-    expect(user.save).toHaveBeenCalled();
     expect(SubscribedUser.prototype.save).toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
   });


### PR DESCRIPTION


- For corporate website newsletter subscriptions, store the email in the SubscribedUser collection.
- For sign-up form subscriptions, add a new field "isSubscribed" in the User model instead of creating a record in SubscribedUser.
- When a user who previously subscribed via the corporate site later creates an account (a likely scenario), remove the SubscribedUser record and update the User model's isSubscribed field to avoid duplicate registrations.
- Utilize sendEmailController to send a welcome/verification email upon registration via Google or the local sign-up form (verification link is not implemented yet).
- Updated the registration flows:
  - This is how a user is registered when subscribing to the newsletter via the corporate website:
    ![Corporate Newsletter Subscription](https://github.com/user-attachments/assets/fcf34190-0fb1-41e1-95b6-1944dfd20cf5)
  - This is how the registration is saved when the user signs up via the email form:
    ![User Registration Flow](https://github.com/user-attachments/assets/eb6ced36-b1db-4290-8e73-83e6aa0e0876)
- Suggestion: For users signing in via Google, consider adding a modal popup to prompt them to subscribe to the newsletter since the current flow doesn’t offer that option.

