### PR TITLE
[FEAT]: update token expiration time

### DIFF
--- a/src/__tests__/services/token/tokenGenerator.test.js
+++ b/src/__tests__/services/token/tokenGenerator.test.js
@@ -20,7 +20,7 @@ describe("generateToken", () => {
     expect(jwt.sign).toHaveBeenCalledWith(
       expect.objectContaining({ email: mockEmail }),
       process.env.JWT_SECRET,
-      { expiresIn: "15m" },
+      { expiresIn: "60m" },
     );
     expect(tokenRepository.saveTokenId).toHaveBeenCalled();
   });

--- a/src/models/token/tokensModel.js
+++ b/src/models/token/tokensModel.js
@@ -13,7 +13,7 @@ const tokenSchema = new mongoose.Schema({
   createdAt: {
     type: Date,
     default: Date.now,
-    expires: 900,
+    expires: 3600,
   },
 });
 

--- a/src/services/token/tokenGenerator.js
+++ b/src/services/token/tokenGenerator.js
@@ -8,7 +8,7 @@ dotenv.config();
 const JWT_SECRET = process.env.JWT_SECRET;
 
 export const generateToken = async (email) => {
-  const expiresIn = "15m";
+  const expiresIn = "60m";
   const tokenId = uuidv4();
 
   const payload = { email, id: tokenId };

--- a/src/templates/confirmSubscriptionTemplate.html
+++ b/src/templates/confirmSubscriptionTemplate.html
@@ -267,7 +267,7 @@
             Verify your email address to complete the subscription to our
             newsletter.
           </p>
-          <p class="content-text">The link expires in <b>6 hours</b>.</p>
+          <p class="content-text">The link expires in <b>1 hour</b>.</p>
         </div>
         <div class="button-container">
           <a href="{{VERIFY_URL}}" class="button">Confirm Subscription</a>

--- a/src/templates/emailWelcomeTemplate.html
+++ b/src/templates/emailWelcomeTemplate.html
@@ -21,10 +21,12 @@
         align-items: center;
         height: 100vh;
       }
+
       a.social-link {
         text-decoration: none;
         color: inherit;
       }
+
       a.social-link img {
         border: none;
         outline: none;

--- a/src/templates/emailWelcomeTemplateGoogle.html
+++ b/src/templates/emailWelcomeTemplateGoogle.html
@@ -21,10 +21,12 @@
         align-items: center;
         height: 100vh;
       }
+
       a.social-link {
         text-decoration: none;
         color: inherit;
       }
+
       a.social-link img {
         border: none;
         outline: none;

--- a/src/templates/verifyEmailForSignupTemplate.html
+++ b/src/templates/verifyEmailForSignupTemplate.html
@@ -22,6 +22,18 @@
         height: 100vh;
       }
 
+      a.social-link {
+        text-decoration: none;
+        color: inherit;
+      }
+
+      a.social-link img {
+        border: none;
+        outline: none;
+        text-decoration: none;
+        display: inline-block;
+      }
+
       .container {
         max-width: 530px;
         margin: auto;
@@ -115,9 +127,7 @@
       }
 
       .socials {
-        display: flex;
-        justify-content: center;
-        align-items: center;
+        text-align: center;
         margin-bottom: 6px;
       }
 

--- a/src/templates/verifyEmailForSignupTemplate.html
+++ b/src/templates/verifyEmailForSignupTemplate.html
@@ -267,7 +267,7 @@
             Verify your email address to complete the signup and log into your
             account.
           </p>
-          <p class="content-text">The link expires in <b>6 hours</b>.</p>
+          <p class="content-text">The link expires in <b>1 hour</b>.</p>
         </div>
         <div class="button-container">
           <a href="{{VERIFY_URL}}" class="button">Verify email</a>

--- a/src/templates/verifyEmailForSignupWithNewsletterTemplate.html
+++ b/src/templates/verifyEmailForSignupWithNewsletterTemplate.html
@@ -22,6 +22,18 @@
         height: 100vh;
       }
 
+      a.social-link {
+        text-decoration: none;
+        color: inherit;
+      }
+
+      a.social-link img {
+        border: none;
+        outline: none;
+        text-decoration: none;
+        display: inline-block;
+      }
+
       .container {
         max-width: 530px;
         margin: auto;
@@ -115,9 +127,7 @@
       }
 
       .socials {
-        display: flex;
-        justify-content: center;
-        align-items: center;
+        text-align: center;
         margin-bottom: 6px;
       }
 

--- a/src/templates/verifyEmailForSignupWithNewsletterTemplate.html
+++ b/src/templates/verifyEmailForSignupWithNewsletterTemplate.html
@@ -267,7 +267,7 @@
             Verify your email address to complete the signup and log into your
             account and verify your subscription to our newsletter.
           </p>
-          <p class="content-text">The link expires in <b>6 hours</b>.</p>
+          <p class="content-text">The link expires in <b>1 hour</b>.</p>
         </div>
         <div class="button-container">
           <a href="{{VERIFY_URL}}" class="button">Verify email</a>


### PR DESCRIPTION
## Token Expiration Time Update

This PR updates the token expiration time from 15 minutes to 60 minutes to provide a compromise between better user experience and security during email verification processes.

### Changes
- Updated token model TTL from 900 to 3600 seconds
- Updated JWT token expiration from 15m to 60m
- Updated email templates to reflect the correct 1-hour expiration time (changed from 6 hours)
    - verifyEmailForSignupTemplate.html
    - verifyEmailForSignupWithNewsletterTemplate.html
    - confirmSubscriptionTemplate.html
- Maintained consistent styling of social links in all email templates
- Update test for token generator.


### Impact
This change provides users with a reasonable timeframe to verify their email addresses without compromising security. The unified 60-minute expiration time works for both the subscription flow and the upcoming signup verification flow.