### PR TITLE
Feat resend email

### DIFF
--- a/src/__tests__/controllers/subscribeControllers/subscribeController.test.js
+++ b/src/__tests__/controllers/subscribeControllers/subscribeController.test.js
@@ -10,11 +10,6 @@ import {
   markTokenAsUsed,
   deleteToken,
 } from "../../../services/token/tokenRepository.js";
-import { generateToken } from "../../../services/token/tokenGenerator.js";
-import {
-  baseApiUrl,
-  baseDonnaVinoWebUrl,
-} from "../../../config/environment.js";
 
 // Mock all external dependencies
 vi.mock("fs");

--- a/src/__tests__/controllers/subscribeControllers/subscribeController.test.js
+++ b/src/__tests__/controllers/subscribeControllers/subscribeController.test.js
@@ -55,273 +55,206 @@ describe("subscribeController", () => {
     vi.clearAllMocks();
   });
 
-  it("should handle missing required fields", async () => {
-    req.body = {};
-    await subscribeController(req, res);
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      message: "Token, subject, and templateName are required.",
-    });
-  });
+  // it("should handle missing required fields", async () => {
+  //   req.body = {};
+  //   await subscribeController(req, res);
+  //   expect(res.status).toHaveBeenCalledWith(400);
+  //   expect(res.json).toHaveBeenCalledWith({
+  //     success: false,
+  //     message: "Token, subject, and templateName are required.",
+  //   });
+  // });
 
-  it("should handle invalid template name", async () => {
-    req.body = {
-      token: "validtoken",
-      subject: "Welcome!",
-      templateName: "invalid@name",
-    };
-    await subscribeController(req, res);
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
-      message: "Invalid template name.",
-    });
-  });
+  // it("should handle invalid template name", async () => {
+  //   req.body = {
+  //     token: "validtoken",
+  //     subject: "Welcome!",
+  //     templateName: "invalid@name",
+  //   };
+  //   await subscribeController(req, res);
+  //   expect(res.status).toHaveBeenCalledWith(400);
+  //   expect(res.json).toHaveBeenCalledWith({
+  //     message: "Invalid template name.",
+  //   });
+  // });
 
-  it("should return 404 if template not found", async () => {
-    req.body = {
-      token: "validtoken",
-      subject: "Welcome!",
-      templateName: "nonexistentTemplate",
-    };
-    fs.existsSync.mockReturnValue(false);
-    await subscribeController(req, res);
-    expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      message: "Email template not found",
-    });
-  });
+  // it("should return 404 if template not found", async () => {
+  //   req.body = {
+  //     token: "validtoken",
+  //     subject: "Welcome!",
+  //     templateName: "nonexistentTemplate",
+  //   };
+  //   fs.existsSync.mockReturnValue(false);
+  //   await subscribeController(req, res);
+  //   expect(res.status).toHaveBeenCalledWith(404);
+  //   expect(res.json).toHaveBeenCalledWith({
+  //     success: false,
+  //     message: "Email template not found",
+  //   });
+  // });
 
-  it("should handle token verification and return 401 if token is invalid", async () => {
-    req.body = {
-      token: "invalidtoken",
-      subject: "Welcome!",
-      templateName: "emailWelcomeTemplate",
-    };
-    jwt.verify.mockImplementationOnce(() => {
-      throw new Error("Invalid token");
-    });
-    await subscribeController(req, res);
-    expect(res.status).toHaveBeenCalledWith(401);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      message: "Invalid or expired token.",
-    });
-  });
+  // it("should handle token verification and return 401 if token is invalid", async () => {
+  //   req.body = {
+  //     token: "invalidtoken",
+  //     subject: "Welcome!",
+  //     templateName: "emailWelcomeTemplate",
+  //   };
+  //   jwt.verify.mockImplementationOnce(() => {
+  //     throw new Error("Invalid token");
+  //   });
+  //   await subscribeController(req, res);
+  //   expect(res.status).toHaveBeenCalledWith(401);
+  //   expect(res.json).toHaveBeenCalledWith({
+  //     success: false,
+  //     message: "Invalid or expired token.",
+  //   });
+  // });
 
-  it("should return 400 if token has already been used", async () => {
-    req.body = {
-      token: "usedtoken",
-      subject: "Welcome!",
-      templateName: "emailWelcomeTemplate",
-    };
-    isTokenUsed.mockResolvedValue(true);
-    await subscribeController(req, res);
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      message: "This token has already been used.",
-    });
-  });
+  // it("should return 400 if token has already been used", async () => {
+  //   req.body = {
+  //     token: "usedtoken",
+  //     subject: "Welcome!",
+  //     templateName: "emailWelcomeTemplate",
+  //   };
+  //   isTokenUsed.mockResolvedValue(true);
+  //   await subscribeController(req, res);
+  //   expect(res.status).toHaveBeenCalledWith(400);
+  //   expect(res.json).toHaveBeenCalledWith({
+  //     success: false,
+  //     message: "This token has already been used.",
+  //   });
+  // });
 
-  it("should return 404 if user is not found in PreSubscribedUser", async () => {
-    req.body = {
-      token: "validtoken",
-      subject: "Welcome!",
-      templateName: "emailWelcomeTemplate",
-    };
-    PreSubscribedUser.findOne.mockResolvedValue(null);
-    await subscribeController(req, res);
-    expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      message: "User not found in PreSubscribedUser",
-    });
-  });
+  // it("should return 404 if user is not found in PreSubscribedUser", async () => {
+  //   req.body = {
+  //     token: "validtoken",
+  //     subject: "Welcome!",
+  //     templateName: "emailWelcomeTemplate",
+  //   };
+  //   PreSubscribedUser.findOne.mockResolvedValue(null);
+  //   await subscribeController(req, res);
+  //   expect(res.status).toHaveBeenCalledWith(404);
+  //   expect(res.json).toHaveBeenCalledWith({
+  //     success: false,
+  //     message: "User not found in PreSubscribedUser",
+  //   });
+  // });
 
-  it("should return 200 if user is already subscribed", async () => {
-    req.body = {
-      token: "validtoken",
-      subject: "Welcome!",
-      templateName: "emailWelcomeTemplate",
-    };
-    PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
-    SubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
-    await subscribeController(req, res);
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({
-      success: true,
-      message: "User is already subscribed.",
-    });
-  });
+  // it("should return 200 if user is already subscribed", async () => {
+  //   req.body = {
+  //     token: "validtoken",
+  //     subject: "Welcome!",
+  //     templateName: "emailWelcomeTemplate",
+  //   };
+  //   PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
+  //   SubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
+  //   await subscribeController(req, res);
+  //   expect(res.status).toHaveBeenCalledWith(200);
+  //   expect(res.json).toHaveBeenCalledWith({
+  //     success: true,
+  //     message: "User is already subscribed.",
+  //   });
+  // });
 
-  it("should successfully subscribe a new user and send a welcome email", async () => {
-    req.body = {
-      token: "validtoken",
-      subject: "Welcome!",
-      templateName: "emailWelcomeTemplate",
-    };
+  // it("should successfully subscribe a new user and send a welcome email", async () => {
+  //   req.body = {
+  //     token: "validtoken",
+  //     subject: "Welcome!",
+  //     templateName: "emailWelcomeTemplate",
+  //   };
 
-    PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
-    SubscribedUser.findOne.mockResolvedValue(null);
+  //   PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
+  //   SubscribedUser.findOne.mockResolvedValue(null);
 
-    SubscribedUser.create.mockResolvedValue({ email: "test@example.com" });
+  //   SubscribedUser.create.mockResolvedValue({ email: "test@example.com" });
 
-    fs.existsSync.mockReturnValue(true);
-    fs.readFileSync.mockReturnValue("Hello {{name}}!");
-    jwt.verify.mockReturnValue({ email: "test@example.com", id: "token123" });
+  //   fs.existsSync.mockReturnValue(true);
+  //   fs.readFileSync.mockReturnValue("Hello {{name}}!");
+  //   jwt.verify.mockReturnValue({ email: "test@example.com", id: "token123" });
 
-    await subscribeController(req, res);
+  //   await subscribeController(req, res);
 
-    expect(sendEmail).toHaveBeenCalledWith(
-      "test@example.com",
-      "Welcome!",
-      "Hello {{name}}!",
-    );
+  //   expect(sendEmail).toHaveBeenCalledWith(
+  //     "test@example.com",
+  //     "Welcome!",
+  //     "Hello {{name}}!",
+  //   );
 
-    expect(PreSubscribedUser.deleteOne).toHaveBeenCalledWith({
-      email: "test@example.com",
-    });
+  //   expect(PreSubscribedUser.deleteOne).toHaveBeenCalledWith({
+  //     email: "test@example.com",
+  //   });
 
-    expect(markTokenAsUsed).toHaveBeenCalledWith("token123");
+  //   expect(markTokenAsUsed).toHaveBeenCalledWith("token123");
 
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({
-      success: true,
-      message:
-        "Subscription confirmed. An email has been sent with unsubscribe options.",
-    });
-  });
+  //   expect(res.status).toHaveBeenCalledWith(200);
+  //   expect(res.json).toHaveBeenCalledWith({
+  //     success: true,
+  //     message:
+  //       "Subscription confirmed. An email has been sent with unsubscribe options.",
+  //   });
+  // });
 
-  it("should return 500 if an error occurs during the process", async () => {
-    req.body = {
-      token: "validtoken",
-      subject: "Welcome!",
-      templateName: "emailWelcomeTemplate",
-    };
+  // it("should return 500 if an error occurs during the process", async () => {
+  //   req.body = {
+  //     token: "validtoken",
+  //     subject: "Welcome!",
+  //     templateName: "emailWelcomeTemplate",
+  //   };
 
-    PreSubscribedUser.findOne.mockRejectedValue(new Error("DB error"));
+  //   PreSubscribedUser.findOne.mockRejectedValue(new Error("DB error"));
 
-    await subscribeController(req, res);
+  //   await subscribeController(req, res);
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      success: false,
-      message: "Internal server error",
-    });
-  });
+  //   expect(res.status).toHaveBeenCalledWith(500);
+  //   expect(res.json).toHaveBeenCalledWith({
+  //     success: false,
+  //     message: "Internal server error",
+  //   });
+  // });
 
-  it("should replace the dynamic URLs in the email template", async () => {
-    req.body = {
-      token: "validtoken",
-      subject: "Welcome!",
-      templateName: "emailWelcomeTemplate",
-    };
+  // it("should replace the dynamic URLs in the email template", async () => {
+  //   req.body = {
+  //     token: "validtoken",
+  //     subject: "Welcome!",
+  //     templateName: "emailWelcomeTemplate",
+  //   };
 
-    PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
-    SubscribedUser.findOne.mockResolvedValue(null);
-    SubscribedUser.create.mockResolvedValue({ email: "test@example.com" });
+  //   PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
+  //   SubscribedUser.findOne.mockResolvedValue(null);
+  //   SubscribedUser.create.mockResolvedValue({ email: "test@example.com" });
 
-    fs.existsSync.mockReturnValue(true);
-    fs.readFileSync.mockReturnValue(
-      "Hello {{name}}! Please click here: {{RE_DIRECT_URL}} or unsubscribe at {{UNSUBSCRIBE_URL}}.",
-    );
-    jwt.verify.mockReturnValue({ email: "test@example.com", id: "token123" });
+  //   fs.existsSync.mockReturnValue(true);
+  //   fs.readFileSync.mockReturnValue(
+  //     "Hello {{name}}! Please click here: {{RE_DIRECT_URL}} or unsubscribe at {{UNSUBSCRIBE_URL}}.",
+  //   );
+  //   jwt.verify.mockReturnValue({ email: "test@example.com", id: "token123" });
 
-    const unsubscribeToken = "unsubscribeToken123";
-    vi.mocked(generateToken).mockResolvedValue(unsubscribeToken);
+  //   const unsubscribeToken = "unsubscribeToken123";
+  //   vi.mocked(generateToken).mockResolvedValue(unsubscribeToken);
 
-    const unsubscribeUrl = `${baseApiUrl}/api/subscribe/un-subscribe?token=${unsubscribeToken}`;
-    const homeUrl = `${baseDonnaVinoWebUrl}`;
+  //   const unsubscribeUrl = `${baseApiUrl}/api/subscribe/un-subscribe?token=${unsubscribeToken}`;
+  //   const homeUrl = `${baseDonnaVinoWebUrl}`;
 
-    await subscribeController(req, res);
+  //   await subscribeController(req, res);
 
-    expect(sendEmail).toHaveBeenCalledWith(
-      "test@example.com",
-      "Welcome!",
-      "Hello {{name}}! Please click here: " +
-        homeUrl +
-        " or unsubscribe at " +
-        unsubscribeUrl +
-        ".",
-    );
+  //   expect(sendEmail).toHaveBeenCalledWith(
+  //     "test@example.com",
+  //     "Welcome!",
+  //     "Hello {{name}}! Please click here: " +
+  //       homeUrl +
+  //       " or unsubscribe at " +
+  //       unsubscribeUrl +
+  //       ".",
+  //   );
 
-    expect(fs.readFileSync).toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({
-      success: true,
-      message:
-        "Subscription confirmed. An email has been sent with unsubscribe options.",
-    });
-  });
-
-  it("should delete the token after successful subscription", async () => {
-    req.body = {
-      token: "validtoken",
-      subject: "Welcome!",
-      templateName: "emailWelcomeTemplate",
-    };
-
-    PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
-    SubscribedUser.findOne.mockResolvedValue(null);
-    SubscribedUser.create.mockResolvedValue({ email: "test@example.com" });
-
-    jwt.verify.mockReturnValue({ email: "test@example.com", id: "token123" });
-
-    await subscribeController(req, res);
-
-    expect(deleteToken).toHaveBeenCalledWith("token123");
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({
-      success: true,
-      message:
-        "Subscription confirmed. An email has been sent with unsubscribe options.",
-    });
-  });
-
-  it("should dynamically generate the unsubscribe URL and include it in the email", async () => {
-    req.body = {
-      token: "validtoken",
-      subject: "Welcome!",
-      templateName: "emailWelcomeTemplate",
-      templateData: { name: "User" },
-    };
-
-    PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
-    SubscribedUser.findOne.mockResolvedValue(null);
-    SubscribedUser.create.mockResolvedValue({ email: "test@example.com" });
-
-    fs.existsSync.mockReturnValue(true);
-    fs.readFileSync.mockReturnValue(
-      "Hello {{name}}! Click here: {{RE_DIRECT_URL}} or unsubscribe here: {{UNSUBSCRIBE_URL}}.",
-    );
-
-    jwt.verify.mockReturnValue({ email: "test@example.com", id: "token123" });
-
-    const unsubscribeToken = "unsubscribeToken123";
-    generateToken.mockResolvedValue(unsubscribeToken);
-
-    const unsubscribeUrl = `${baseApiUrl}/api/subscribe/un-subscribe?token=${unsubscribeToken}`;
-    const homeUrl = `${baseDonnaVinoWebUrl}`;
-
-    await subscribeController(req, res);
-
-    expect(generateToken).toHaveBeenCalledWith("test@example.com");
-
-    expect(sendEmail).toHaveBeenCalledWith(
-      "test@example.com",
-      "Welcome!",
-      `Hello User! Click here: ${homeUrl} or unsubscribe here: ${unsubscribeUrl}.`,
-    );
-
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({
-      success: true,
-      message:
-        "Subscription confirmed. An email has been sent with unsubscribe options.",
-    });
-  });
+  //   expect(fs.readFileSync).toHaveBeenCalled();
+  //   expect(res.status).toHaveBeenCalledWith(200);
+  //   expect(res.json).toHaveBeenCalledWith({
+  //     success: true,
+  //     message:
+  //       "Subscription confirmed. An email has been sent with unsubscribe options.",
+  //   });
+  // });
 
   it("should delete the token after verifying the user in PreSubscribedUser", async () => {
     req.body = {

--- a/src/__tests__/controllers/subscribeControllers/subscribeController.test.js
+++ b/src/__tests__/controllers/subscribeControllers/subscribeController.test.js
@@ -10,6 +10,11 @@ import {
   markTokenAsUsed,
   deleteToken,
 } from "../../../services/token/tokenRepository.js";
+import { generateToken } from "../../../services/token/tokenGenerator.js";
+import {
+  baseApiUrl,
+  baseDonnaVinoWebUrl,
+} from "../../../config/environment.js";
 
 // Mock all external dependencies
 vi.mock("fs");
@@ -50,206 +55,206 @@ describe("subscribeController", () => {
     vi.clearAllMocks();
   });
 
-  // it("should handle missing required fields", async () => {
-  //   req.body = {};
-  //   await subscribeController(req, res);
-  //   expect(res.status).toHaveBeenCalledWith(400);
-  //   expect(res.json).toHaveBeenCalledWith({
-  //     success: false,
-  //     message: "Token, subject, and templateName are required.",
-  //   });
-  // });
+  it("should handle missing required fields", async () => {
+    req.body = {};
+    await subscribeController(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Token, subject, and templateName are required.",
+    });
+  });
 
-  // it("should handle invalid template name", async () => {
-  //   req.body = {
-  //     token: "validtoken",
-  //     subject: "Welcome!",
-  //     templateName: "invalid@name",
-  //   };
-  //   await subscribeController(req, res);
-  //   expect(res.status).toHaveBeenCalledWith(400);
-  //   expect(res.json).toHaveBeenCalledWith({
-  //     message: "Invalid template name.",
-  //   });
-  // });
+  it("should handle invalid template name", async () => {
+    req.body = {
+      token: "validtoken",
+      subject: "Welcome!",
+      templateName: "invalid@name",
+    };
+    await subscribeController(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      message: "Invalid template name.",
+    });
+  });
 
-  // it("should return 404 if template not found", async () => {
-  //   req.body = {
-  //     token: "validtoken",
-  //     subject: "Welcome!",
-  //     templateName: "nonexistentTemplate",
-  //   };
-  //   fs.existsSync.mockReturnValue(false);
-  //   await subscribeController(req, res);
-  //   expect(res.status).toHaveBeenCalledWith(404);
-  //   expect(res.json).toHaveBeenCalledWith({
-  //     success: false,
-  //     message: "Email template not found",
-  //   });
-  // });
+  it("should return 404 if template not found", async () => {
+    req.body = {
+      token: "validtoken",
+      subject: "Welcome!",
+      templateName: "nonexistentTemplate",
+    };
+    fs.existsSync.mockReturnValue(false);
+    await subscribeController(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Email template not found",
+    });
+  });
 
-  // it("should handle token verification and return 401 if token is invalid", async () => {
-  //   req.body = {
-  //     token: "invalidtoken",
-  //     subject: "Welcome!",
-  //     templateName: "emailWelcomeTemplate",
-  //   };
-  //   jwt.verify.mockImplementationOnce(() => {
-  //     throw new Error("Invalid token");
-  //   });
-  //   await subscribeController(req, res);
-  //   expect(res.status).toHaveBeenCalledWith(401);
-  //   expect(res.json).toHaveBeenCalledWith({
-  //     success: false,
-  //     message: "Invalid or expired token.",
-  //   });
-  // });
+  it("should handle token verification and return 401 if token is invalid", async () => {
+    req.body = {
+      token: "invalidtoken",
+      subject: "Welcome!",
+      templateName: "emailWelcomeTemplate",
+    };
+    jwt.verify.mockImplementationOnce(() => {
+      throw new Error("Invalid token");
+    });
+    await subscribeController(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Invalid or expired token.",
+    });
+  });
 
-  // it("should return 400 if token has already been used", async () => {
-  //   req.body = {
-  //     token: "usedtoken",
-  //     subject: "Welcome!",
-  //     templateName: "emailWelcomeTemplate",
-  //   };
-  //   isTokenUsed.mockResolvedValue(true);
-  //   await subscribeController(req, res);
-  //   expect(res.status).toHaveBeenCalledWith(400);
-  //   expect(res.json).toHaveBeenCalledWith({
-  //     success: false,
-  //     message: "This token has already been used.",
-  //   });
-  // });
+  it("should return 400 if token has already been used", async () => {
+    req.body = {
+      token: "usedtoken",
+      subject: "Welcome!",
+      templateName: "emailWelcomeTemplate",
+    };
+    isTokenUsed.mockResolvedValue(true);
+    await subscribeController(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "This token has already been used.",
+    });
+  });
 
-  // it("should return 404 if user is not found in PreSubscribedUser", async () => {
-  //   req.body = {
-  //     token: "validtoken",
-  //     subject: "Welcome!",
-  //     templateName: "emailWelcomeTemplate",
-  //   };
-  //   PreSubscribedUser.findOne.mockResolvedValue(null);
-  //   await subscribeController(req, res);
-  //   expect(res.status).toHaveBeenCalledWith(404);
-  //   expect(res.json).toHaveBeenCalledWith({
-  //     success: false,
-  //     message: "User not found in PreSubscribedUser",
-  //   });
-  // });
+  it("should return 404 if user is not found in PreSubscribedUser", async () => {
+    req.body = {
+      token: "validtoken",
+      subject: "Welcome!",
+      templateName: "emailWelcomeTemplate",
+    };
+    PreSubscribedUser.findOne.mockResolvedValue(null);
+    await subscribeController(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "User not found in PreSubscribedUser",
+    });
+  });
 
-  // it("should return 200 if user is already subscribed", async () => {
-  //   req.body = {
-  //     token: "validtoken",
-  //     subject: "Welcome!",
-  //     templateName: "emailWelcomeTemplate",
-  //   };
-  //   PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
-  //   SubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
-  //   await subscribeController(req, res);
-  //   expect(res.status).toHaveBeenCalledWith(200);
-  //   expect(res.json).toHaveBeenCalledWith({
-  //     success: true,
-  //     message: "User is already subscribed.",
-  //   });
-  // });
+  it("should return 200 if user is already subscribed", async () => {
+    req.body = {
+      token: "validtoken",
+      subject: "Welcome!",
+      templateName: "emailWelcomeTemplate",
+    };
+    PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
+    SubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
+    await subscribeController(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: "User is already subscribed.",
+    });
+  });
 
-  // it("should successfully subscribe a new user and send a welcome email", async () => {
-  //   req.body = {
-  //     token: "validtoken",
-  //     subject: "Welcome!",
-  //     templateName: "emailWelcomeTemplate",
-  //   };
+  it("should successfully subscribe a new user and send a welcome email", async () => {
+    req.body = {
+      token: "validtoken",
+      subject: "Welcome!",
+      templateName: "emailWelcomeTemplate",
+    };
 
-  //   PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
-  //   SubscribedUser.findOne.mockResolvedValue(null);
+    PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
+    SubscribedUser.findOne.mockResolvedValue(null);
 
-  //   SubscribedUser.create.mockResolvedValue({ email: "test@example.com" });
+    SubscribedUser.create.mockResolvedValue({ email: "test@example.com" });
 
-  //   fs.existsSync.mockReturnValue(true);
-  //   fs.readFileSync.mockReturnValue("Hello {{name}}!");
-  //   jwt.verify.mockReturnValue({ email: "test@example.com", id: "token123" });
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue("Hello {{name}}!");
+    jwt.verify.mockReturnValue({ email: "test@example.com", id: "token123" });
 
-  //   await subscribeController(req, res);
+    await subscribeController(req, res);
 
-  //   expect(sendEmail).toHaveBeenCalledWith(
-  //     "test@example.com",
-  //     "Welcome!",
-  //     "Hello {{name}}!",
-  //   );
+    expect(sendEmail).toHaveBeenCalledWith(
+      "test@example.com",
+      "Welcome!",
+      "Hello {{name}}!",
+    );
 
-  //   expect(PreSubscribedUser.deleteOne).toHaveBeenCalledWith({
-  //     email: "test@example.com",
-  //   });
+    expect(PreSubscribedUser.deleteOne).toHaveBeenCalledWith({
+      email: "test@example.com",
+    });
 
-  //   expect(markTokenAsUsed).toHaveBeenCalledWith("token123");
+    expect(markTokenAsUsed).toHaveBeenCalledWith("token123");
 
-  //   expect(res.status).toHaveBeenCalledWith(200);
-  //   expect(res.json).toHaveBeenCalledWith({
-  //     success: true,
-  //     message:
-  //       "Subscription confirmed. An email has been sent with unsubscribe options.",
-  //   });
-  // });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message:
+        "Subscription confirmed. An email has been sent with unsubscribe options.",
+    });
+  });
 
-  // it("should return 500 if an error occurs during the process", async () => {
-  //   req.body = {
-  //     token: "validtoken",
-  //     subject: "Welcome!",
-  //     templateName: "emailWelcomeTemplate",
-  //   };
+  it("should return 500 if an error occurs during the process", async () => {
+    req.body = {
+      token: "validtoken",
+      subject: "Welcome!",
+      templateName: "emailWelcomeTemplate",
+    };
 
-  //   PreSubscribedUser.findOne.mockRejectedValue(new Error("DB error"));
+    PreSubscribedUser.findOne.mockRejectedValue(new Error("DB error"));
 
-  //   await subscribeController(req, res);
+    await subscribeController(req, res);
 
-  //   expect(res.status).toHaveBeenCalledWith(500);
-  //   expect(res.json).toHaveBeenCalledWith({
-  //     success: false,
-  //     message: "Internal server error",
-  //   });
-  // });
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: "Internal server error",
+    });
+  });
 
-  // it("should replace the dynamic URLs in the email template", async () => {
-  //   req.body = {
-  //     token: "validtoken",
-  //     subject: "Welcome!",
-  //     templateName: "emailWelcomeTemplate",
-  //   };
+  it("should replace the dynamic URLs in the email template", async () => {
+    req.body = {
+      token: "validtoken",
+      subject: "Welcome!",
+      templateName: "emailWelcomeTemplate",
+    };
 
-  //   PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
-  //   SubscribedUser.findOne.mockResolvedValue(null);
-  //   SubscribedUser.create.mockResolvedValue({ email: "test@example.com" });
+    PreSubscribedUser.findOne.mockResolvedValue({ email: "test@example.com" });
+    SubscribedUser.findOne.mockResolvedValue(null);
+    SubscribedUser.create.mockResolvedValue({ email: "test@example.com" });
 
-  //   fs.existsSync.mockReturnValue(true);
-  //   fs.readFileSync.mockReturnValue(
-  //     "Hello {{name}}! Please click here: {{RE_DIRECT_URL}} or unsubscribe at {{UNSUBSCRIBE_URL}}.",
-  //   );
-  //   jwt.verify.mockReturnValue({ email: "test@example.com", id: "token123" });
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue(
+      "Hello {{name}}! Please click here: {{RE_DIRECT_URL}} or unsubscribe at {{UNSUBSCRIBE_URL}}.",
+    );
+    jwt.verify.mockReturnValue({ email: "test@example.com", id: "token123" });
 
-  //   const unsubscribeToken = "unsubscribeToken123";
-  //   vi.mocked(generateToken).mockResolvedValue(unsubscribeToken);
+    const unsubscribeToken = "unsubscribeToken123";
+    vi.mocked(generateToken).mockResolvedValue(unsubscribeToken);
 
-  //   const unsubscribeUrl = `${baseApiUrl}/api/subscribe/un-subscribe?token=${unsubscribeToken}`;
-  //   const homeUrl = `${baseDonnaVinoWebUrl}`;
+    const unsubscribeUrl = `${baseApiUrl}/api/subscribe/un-subscribe?token=${unsubscribeToken}`;
+    const homeUrl = `${baseDonnaVinoWebUrl}`;
 
-  //   await subscribeController(req, res);
+    await subscribeController(req, res);
 
-  //   expect(sendEmail).toHaveBeenCalledWith(
-  //     "test@example.com",
-  //     "Welcome!",
-  //     "Hello {{name}}! Please click here: " +
-  //       homeUrl +
-  //       " or unsubscribe at " +
-  //       unsubscribeUrl +
-  //       ".",
-  //   );
+    expect(sendEmail).toHaveBeenCalledWith(
+      "test@example.com",
+      "Welcome!",
+      "Hello {{name}}! Please click here: " +
+        homeUrl +
+        " or unsubscribe at " +
+        unsubscribeUrl +
+        ".",
+    );
 
-  //   expect(fs.readFileSync).toHaveBeenCalled();
-  //   expect(res.status).toHaveBeenCalledWith(200);
-  //   expect(res.json).toHaveBeenCalledWith({
-  //     success: true,
-  //     message:
-  //       "Subscription confirmed. An email has been sent with unsubscribe options.",
-  //   });
-  // });
+    expect(fs.readFileSync).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message:
+        "Subscription confirmed. An email has been sent with unsubscribe options.",
+    });
+  });
 
   it("should delete the token after verifying the user in PreSubscribedUser", async () => {
     req.body = {

--- a/src/controllers/subscribeControllers/subscribeController.js
+++ b/src/controllers/subscribeControllers/subscribeController.js
@@ -123,6 +123,7 @@ export const subscribeController = async (req, res) => {
 
     logInfo(`Marking token as used: ${tokenId}`);
     await markTokenAsUsed(tokenId);
+
     logInfo(`Deleting token: ${tokenId}`);
     await deleteToken(tokenId);
 

--- a/src/services/token/tokenRepository.js
+++ b/src/services/token/tokenRepository.js
@@ -1,9 +1,10 @@
 import Token from "../../models/token/tokensModel.js";
-import { logError } from "../../util/logging.js";
+import { logError, logInfo } from "../../util/logging.js";
 
 export const saveTokenId = async (id) => {
   try {
     await Token.create({ id });
+    logInfo("Token saved successfully");
   } catch (error) {
     logError("Error saving token:", error);
   }
@@ -11,12 +12,14 @@ export const saveTokenId = async (id) => {
 
 export const isTokenUsed = async (id) => {
   const token = await Token.findOne({ id });
+  logInfo("Checking if the token is used");
   return token?.used || !token;
 };
 
 export const markTokenAsUsed = async (id) => {
   try {
     await Token.findOneAndUpdate({ id }, { used: true });
+    logInfo("Token marked as used");
   } catch (error) {
     logError("Error marking token as used:", error);
   }
@@ -25,6 +28,7 @@ export const markTokenAsUsed = async (id) => {
 export const deleteToken = async (id) => {
   try {
     await Token.deleteOne({ id });
+    logInfo("Token deleted");
   } catch (error) {
     logError("Error deleting token:", error);
   }


### PR DESCRIPTION
This pull request focuses on cleaning up the tests related to token creation and adding additional logInfo statements for better debugging during the email verification process.

I manually verified that the token is created, marked as used, and then deleted. Afterward, a new token is created and sent in a new email.


![Captura de Pantalla 2025-03-14 a la(s) 10 03 56](https://github.com/user-attachments/assets/2c96f407-d02f-4635-9aca-7360ec648a2c)

