### PR TITLE
[FIX] User Already Exists Error Response in Pre-Signup Flow

### DIFF
--- a/src/__tests__/controllers/authControllers/preSignUpController.test.js
+++ b/src/__tests__/controllers/authControllers/preSignUpController.test.js
@@ -142,10 +142,10 @@ describe("preSignUp Controller", () => {
     await preSignUp(req, res);
 
     expect(User.findOne).toHaveBeenCalledWith({ email: validUserData.email });
-    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.status).toHaveBeenCalledWith(409);
     expect(res.json).toHaveBeenCalledWith({
-      success: true,
-      msg: "User already exists.",
+      success: false,
+      msg: "A user with this email already exists. Please try logging in instead.",
     });
   });
 

--- a/src/controllers/authControllers/preSignUpController.js
+++ b/src/controllers/authControllers/preSignUpController.js
@@ -75,10 +75,10 @@ export const preSignUp = async (req, res) => {
   try {
     existingUser = await User.findOne({ email });
     if (existingUser) {
-      logInfo(`User with email ${email} already exists, returning user info`);
-      return res.status(200).json({
-        success: true,
-        msg: "User already exists.",
+      logInfo(`User with email ${email} already exists`);
+      return res.status(409).json({
+        success: false,
+        msg: "A user with this email already exists. Please try logging in instead.",
       });
     }
   } catch (dbError) {


### PR DESCRIPTION
# [FIX] User Already Exists Error Response in Pre-Signup Flow
## Changes
This PR implements improvements to the pre-signup error handling:
- Changed the HTTP status code from 200 to 409 (Conflict) when a user with the same email already exists
- Updated the success flag from true to false in the error response

## Rationale
The 409 Conflict status code is the appropriate response when a resource already exists, rather than returning a 200 OK with an error message