### PR TITLE
[FEATURE] Add Resend Verification Endpoint with Email Service Refactoring

### DIFF
--- a/src/__tests__/controllers/authControllers/resendVerificationController.test.js
+++ b/src/__tests__/controllers/authControllers/resendVerificationController.test.js
@@ -1,0 +1,204 @@
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.test" });
+import { describe, it, beforeEach, afterEach, expect, vi } from "vitest";
+import { resendVerificationEmail } from "../../../controllers/authControllers/resendVerificationController.js";
+import fs from "fs";
+import path from "path";
+import { sendEmail } from "../../../util/emailUtils.js";
+import PendingUser from "../../../models/users/pendingUserModel.js";
+import { generateToken } from "../../../services/token/tokenGenerator.js";
+import { logError, logInfo } from "../../../util/logging.js";
+
+vi.mock("fs");
+vi.mock("path");
+vi.mock("../../../util/emailUtils.js");
+vi.mock("../../../models/users/pendingUserModel.js");
+vi.mock("../../../services/token/tokenGenerator.js");
+vi.mock("../../../util/logging.js");
+
+describe("resendVerificationEmail Controller", () => {
+  let req, res;
+  const mockToken = "mock-verification-token";
+  const mockEmail = "test.user@example.com";
+  const lowerCaseEmail = "test.user@example.com";
+  const mockPendingUser = {
+    _id: "mock-pending-user-id",
+    email: lowerCaseEmail,
+    firstName: "Test",
+    lastName: "User",
+    isSubscribed: false,
+  };
+
+  beforeEach(() => {
+    req = {
+      query: {
+        email: mockEmail,
+      },
+    };
+
+    res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    // Setup default mock behavior
+    fs.readFileSync.mockReturnValue("{{VERIFY_URL}}");
+    path.resolve.mockReturnValue("/mock/path/to/template.html");
+    sendEmail.mockResolvedValue(true);
+    generateToken.mockResolvedValue(mockToken);
+    PendingUser.findOne.mockResolvedValue(mockPendingUser);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 if email is missing", async () => {
+    req.query = {};
+
+    await resendVerificationEmail(req, res);
+
+    expect(logError).toHaveBeenCalledWith(
+      "Missing email in resend verification request",
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      msg: "Email is required to resend verification",
+    });
+  });
+
+  it("normalizes email to lowercase", async () => {
+    req.query.email = "Test.User@Example.com";
+
+    await resendVerificationEmail(req, res);
+
+    expect(PendingUser.findOne).toHaveBeenCalledWith({
+      email: "test.user@example.com",
+    });
+  });
+
+  it("returns 404 if no pending user is found", async () => {
+    PendingUser.findOne.mockResolvedValueOnce(null);
+
+    await resendVerificationEmail(req, res);
+
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `No pending user found for email: ${lowerCaseEmail}`,
+      ),
+    );
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      msg: "No pending registration found for this email. Please sign up first.",
+    });
+  });
+
+  it("handles database error when finding pending user", async () => {
+    PendingUser.findOne.mockRejectedValueOnce(
+      new Error("Database connection error"),
+    );
+
+    await resendVerificationEmail(req, res);
+
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining("Database error finding pending user for resend"),
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      msg: "Unable to process your request. Please try again later.",
+    });
+  });
+
+  it("handles token generation error", async () => {
+    generateToken.mockRejectedValueOnce(new Error("Token generation failed"));
+
+    await resendVerificationEmail(req, res);
+
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining("Error generating new token for resend"),
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      msg: "Unable to create verification token. Please try again later.",
+    });
+  });
+
+  it("handles email sending error", async () => {
+    sendEmail.mockRejectedValueOnce(new Error("Email sending failed"));
+
+    await resendVerificationEmail(req, res);
+
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining("Error sending resend verification email"),
+    );
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      msg: "Unable to send verification email. Please try again later.",
+    });
+  });
+
+  it("selects the correct email template based on isSubscribed", async () => {
+    // Test with subscribed user
+    const subscribedUser = {
+      ...mockPendingUser,
+      isSubscribed: true,
+    };
+    PendingUser.findOne.mockResolvedValueOnce(subscribedUser);
+
+    await resendVerificationEmail(req, res);
+
+    expect(path.resolve).toHaveBeenCalledWith(
+      expect.any(String),
+      "src/templates/verifyEmailForSignupWithNewsletterTemplate.html",
+    );
+
+    // Test with non-subscribed user
+    vi.clearAllMocks();
+    PendingUser.findOne.mockResolvedValueOnce(mockPendingUser);
+    generateToken.mockResolvedValue(mockToken);
+
+    await resendVerificationEmail(req, res);
+
+    expect(path.resolve).toHaveBeenCalledWith(
+      expect.any(String),
+      "src/templates/verifyEmailForSignupTemplate.html",
+    );
+  });
+
+  it("successfully resends verification email", async () => {
+    await resendVerificationEmail(req, res);
+
+    // Verify token was generated
+    expect(generateToken).toHaveBeenCalledWith(lowerCaseEmail);
+    expect(logInfo).toHaveBeenCalledWith(
+      `Generated new verification token for ${lowerCaseEmail}`,
+    );
+
+    // Verify email was sent with correct parameters
+    expect(sendEmail).toHaveBeenCalledWith(
+      mockPendingUser.email,
+      "Verify your email address for Donna Vino",
+      expect.any(String),
+    );
+    expect(logInfo).toHaveBeenCalledWith(
+      `New verification email sent to ${mockPendingUser.email}`,
+    );
+
+    // Verify successful response
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      msg: "Verification email resent. Please check your inbox to complete the signup process.",
+      pendingUser: {
+        email: mockPendingUser.email,
+        firstName: mockPendingUser.firstName,
+        lastName: mockPendingUser.lastName,
+      },
+    });
+  });
+});

--- a/src/__tests__/controllers/authControllers/signupController.test.js
+++ b/src/__tests__/controllers/authControllers/signupController.test.js
@@ -15,6 +15,7 @@ import {
 } from "../../../services/token/tokenRepository.js";
 import { baseDonnaVinoEcommerceWebUrl } from "../../../config/environment.js";
 import { logError, logInfo } from "../../../util/logging.js";
+import { sendVerificationEmail } from "../../../services/email/verificationEmailService.js";
 
 vi.mock("fs");
 vi.mock("path");
@@ -27,6 +28,7 @@ vi.mock("../../../config/environment.js", () => ({
   baseDonnaVinoEcommerceWebUrl: "http://localhost:3000",
 }));
 vi.mock("../../../util/logging.js");
+vi.mock("../../../services/email/verificationEmailService.js");
 
 describe("SignUp Controller", () => {
   let req, res;
@@ -138,6 +140,105 @@ describe("SignUp Controller", () => {
       `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=expired`,
     );
     expect(logError).toHaveBeenCalled();
+  });
+
+  it("resends verification email when token is expired and pending user exists", async () => {
+    // Setup for expired token
+    jwt.verify.mockImplementationOnce(() => {
+      const error = new Error("Token expired");
+      error.name = "TokenExpiredError";
+      throw error;
+    });
+
+    // Setup for token decoding
+    jwt.decode.mockReturnValueOnce({
+      email: mockEmail,
+      id: mockTokenId,
+    });
+
+    // Setup the pending user to be found
+    PendingUser.findOne.mockResolvedValueOnce(pendingUserData);
+
+    // Setup for the verification email to be sent
+    sendVerificationEmail.mockResolvedValueOnce(true);
+
+    await signUp(req, res);
+
+    // Verify token was marked as used and deleted
+    expect(markTokenAsUsed).toHaveBeenCalledWith(mockTokenId);
+    expect(deleteToken).toHaveBeenCalledWith(mockTokenId);
+
+    // Verify a new verification email was sent
+    expect(sendVerificationEmail).toHaveBeenCalledWith(pendingUserData);
+    expect(logInfo).toHaveBeenCalledWith(
+      `Verification email resent to ${mockEmail} due to expired token`,
+    );
+
+    // Verify the redirect includes the resent parameter
+    expect(res.redirect).toHaveBeenCalledWith(
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=expired&resent=true`,
+    );
+  });
+
+  it("redirects to expired token page without resend when pending user not found", async () => {
+    // Setup for expired token
+    jwt.verify.mockImplementationOnce(() => {
+      const error = new Error("Token expired");
+      error.name = "TokenExpiredError";
+      throw error;
+    });
+
+    // Setup for token decoding
+    jwt.decode.mockReturnValueOnce({
+      email: mockEmail,
+      id: mockTokenId,
+    });
+
+    // Setup for pending user NOT found
+    PendingUser.findOne.mockResolvedValueOnce(null);
+
+    await signUp(req, res);
+
+    // Verify no verification email was sent
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
+
+    // Verify standard expired token redirect without resent parameter
+    expect(res.redirect).toHaveBeenCalledWith(
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=expired`,
+    );
+  });
+
+  it("handles errors during the resend verification process", async () => {
+    // Setup for expired token
+    jwt.verify.mockImplementationOnce(() => {
+      const error = new Error("Token expired");
+      error.name = "TokenExpiredError";
+      throw error;
+    });
+
+    // Setup for token decoding
+    jwt.decode.mockReturnValueOnce({
+      email: mockEmail,
+      id: mockTokenId,
+    });
+
+    // Setup the pending user to be found
+    PendingUser.findOne.mockResolvedValueOnce(pendingUserData);
+
+    // Setup for error during verification email send
+    sendVerificationEmail.mockRejectedValueOnce(
+      new Error("Email sending failed"),
+    );
+
+    await signUp(req, res);
+
+    // Verify error was logged
+    expect(logError).toHaveBeenCalled();
+
+    // Verify standard expired token redirect without resent parameter
+    expect(res.redirect).toHaveBeenCalledWith(
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=expired`,
+    );
   });
 
   it("redirects when token is invalid", async () => {

--- a/src/__tests__/controllers/authControllers/signupController.test.js
+++ b/src/__tests__/controllers/authControllers/signupController.test.js
@@ -109,7 +109,7 @@ describe("SignUp Controller", () => {
     await signUp(req, res);
 
     expect(res.redirect).toHaveBeenCalledWith(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=missing_token`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=missing`,
     );
     expect(logError).toHaveBeenCalled();
   });
@@ -121,7 +121,7 @@ describe("SignUp Controller", () => {
 
     expect(isTokenUsed).toHaveBeenCalledWith(mockTokenId);
     expect(res.redirect).toHaveBeenCalledWith(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?token=${mockToken}&reason=token_used`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=invalid`,
     );
   });
 
@@ -135,7 +135,7 @@ describe("SignUp Controller", () => {
     await signUp(req, res);
 
     expect(res.redirect).toHaveBeenCalledWith(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?token=${mockToken}&reason=token_expired`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=expired`,
     );
     expect(logError).toHaveBeenCalled();
   });
@@ -150,7 +150,7 @@ describe("SignUp Controller", () => {
     await signUp(req, res);
 
     expect(res.redirect).toHaveBeenCalledWith(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=token_invalid`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=invalid`,
     );
     expect(logError).toHaveBeenCalled();
   });
@@ -161,7 +161,7 @@ describe("SignUp Controller", () => {
     await signUp(req, res);
 
     expect(res.redirect).toHaveBeenCalledWith(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?token=${mockToken}&reason=no_pending_user`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=not_found`,
     );
     expect(logError).toHaveBeenCalled();
   });
@@ -187,7 +187,7 @@ describe("SignUp Controller", () => {
     await signUp(req, res);
 
     expect(res.redirect).toHaveBeenCalledWith(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=system_error`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=error`,
     );
     expect(logError).toHaveBeenCalled();
   });

--- a/src/__tests__/services/email/verificationEmailService.test.js
+++ b/src/__tests__/services/email/verificationEmailService.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { sendVerificationEmail } from "../../../services/email/verificationEmailService.js";
+import { generateToken } from "../../../services/token/tokenGenerator.js";
+import { sendEmail } from "../../../util/emailUtils.js";
+import fs from "fs";
+import { logError, logInfo } from "../../../util/logging.js";
+
+// Mock dependencies
+vi.mock("../../../services/token/tokenGenerator.js");
+vi.mock("../../../util/emailUtils.js");
+vi.mock("fs");
+vi.mock("../../../util/logging.js");
+
+describe("verificationEmailService", () => {
+  const mockUser = {
+    email: "test@example.com",
+    firstName: "Test",
+    lastName: "User",
+    isSubscribed: false,
+  };
+
+  const mockSubscribedUser = {
+    ...mockUser,
+    isSubscribed: true,
+  };
+
+  const mockToken = "mock-token-12345";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generateToken.mockResolvedValue(mockToken);
+    fs.readFileSync.mockReturnValue("Template with {{VERIFY_URL}}");
+    sendEmail.mockResolvedValue(true);
+  });
+
+  it("should generate a token and send an email for a standard user", async () => {
+    await sendVerificationEmail(mockUser);
+
+    // Verify token was generated
+    expect(generateToken).toHaveBeenCalledWith(mockUser.email);
+
+    // Verify correct template was selected
+    expect(fs.readFileSync).toHaveBeenCalledWith(
+      expect.stringContaining("verifyEmailForSignupTemplate.html"),
+      "utf-8",
+    );
+
+    // Verify email was sent with correct data
+    expect(sendEmail).toHaveBeenCalledWith(
+      mockUser.email,
+      "Verify your email address for Donna Vino",
+      expect.any(String),
+    );
+
+    // Verify log was created
+    expect(logInfo).toHaveBeenCalledWith(
+      `Verification email sent to ${mockUser.email}`,
+    );
+  });
+
+  it("should use newsletter template for subscribed users", async () => {
+    await sendVerificationEmail(mockSubscribedUser);
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "verifyEmailForSignupWithNewsletterTemplate.html",
+      ),
+      "utf-8",
+    );
+  });
+
+  it("should handle token generation errors", async () => {
+    const error = new Error("Token generation error");
+    generateToken.mockRejectedValueOnce(error);
+
+    await expect(sendVerificationEmail(mockUser)).rejects.toThrow();
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining("Error sending verification email"),
+    );
+  });
+
+  it("should handle email sending errors", async () => {
+    const error = new Error("Email sending error");
+    sendEmail.mockRejectedValueOnce(error);
+
+    await expect(sendVerificationEmail(mockUser)).rejects.toThrow();
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining("Error sending verification email"),
+    );
+  });
+});

--- a/src/controllers/authControllers/resendVerificationController.js
+++ b/src/controllers/authControllers/resendVerificationController.js
@@ -1,0 +1,40 @@
+import { logError } from "../../util/logging.js";
+import PendingUser from "../../models/users/pendingUserModel.js";
+
+export const resendVerificationEmail = async (req, res) => {
+  const { email } = req.query;
+
+  if (!email) {
+    logError("Missing email in resend verification request");
+    return res.status(400).json({
+      success: false,
+      msg: "Email is required to resend verification",
+    });
+  }
+
+  const normalizedEmail = email.toLowerCase();
+
+  // Find pending user by email
+  let pendingUser;
+  try {
+    pendingUser = await PendingUser.findOne({ email: normalizedEmail });
+
+    if (!pendingUser) {
+      logError(
+        `No pending user found for email: ${normalizedEmail} when trying to resend verification`,
+      );
+      return res.status(404).json({
+        success: false,
+        msg: "No pending registration found for this email. Please sign up first.",
+      });
+    }
+  } catch (dbError) {
+    logError(
+      `Database error finding pending user for resend: ${dbError.message}`,
+    );
+    return res.status(500).json({
+      success: false,
+      msg: "Unable to process your request. Please try again later.",
+    });
+  }
+};

--- a/src/controllers/authControllers/resendVerificationController.js
+++ b/src/controllers/authControllers/resendVerificationController.js
@@ -1,5 +1,6 @@
-import { logError } from "../../util/logging.js";
+import { logError, logInfo } from "../../util/logging.js";
 import PendingUser from "../../models/users/pendingUserModel.js";
+import { generateToken } from "../../services/token/tokenGenerator.js";
 
 export const resendVerificationEmail = async (req, res) => {
   const { email } = req.query;
@@ -35,6 +36,19 @@ export const resendVerificationEmail = async (req, res) => {
     return res.status(500).json({
       success: false,
       msg: "Unable to process your request. Please try again later.",
+    });
+  }
+
+  // Generate new verification token
+  let token;
+  try {
+    token = await generateToken(normalizedEmail);
+    logInfo(`Generated new verification token for ${normalizedEmail}`);
+  } catch (tokenError) {
+    logError(`Error generating new token for resend: ${tokenError.message}`);
+    return res.status(500).json({
+      success: false,
+      msg: "Unable to create verification token. Please try again later.",
     });
   }
 };

--- a/src/controllers/authControllers/signupController.js
+++ b/src/controllers/authControllers/signupController.js
@@ -19,7 +19,7 @@ export const signUp = async (req, res) => {
   if (!token) {
     logError("Missing token in verification request");
     return res.redirect(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=missing_token`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=missing`,
     );
   }
 
@@ -32,17 +32,17 @@ export const signUp = async (req, res) => {
     if (error.name === "TokenExpiredError") {
       logError(`Token expired: ${token}`);
       return res.redirect(
-        `${baseDonnaVinoEcommerceWebUrl}/verification-failed?token=${token}&reason=token_expired`,
+        `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=expired`,
       );
     } else if (error.name === "JsonWebTokenError") {
       logError(`Invalid token: ${token}, error: ${error.message}`);
       return res.redirect(
-        `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=token_invalid`,
+        `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=invalid`,
       );
     } else {
       logError(`Error verifying token: ${error.message}`);
       return res.redirect(
-        `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=system_error`,
+        `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=error`,
       );
     }
   }
@@ -52,13 +52,13 @@ export const signUp = async (req, res) => {
     if (await isTokenUsed(decoded.id)) {
       logError(`Token ${decoded.id} has already been used`);
       return res.redirect(
-        `${baseDonnaVinoEcommerceWebUrl}/verification-failed?token=${token}&reason=token_used`,
+        `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=invalid`,
       );
     }
   } catch (error) {
     logError(`Error checking if token is used: ${error.message}`);
     return res.redirect(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=system_error`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=error`,
     );
   }
 
@@ -68,7 +68,7 @@ export const signUp = async (req, res) => {
   } catch (error) {
     logError(`Error marking token as used: ${error.message}`);
     return res.redirect(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=system_error`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=error`,
     );
   }
 
@@ -80,13 +80,13 @@ export const signUp = async (req, res) => {
     if (!pendingUser) {
       logError(`No pending user found for email: ${decoded.email}`);
       return res.redirect(
-        `${baseDonnaVinoEcommerceWebUrl}/verification-failed?token=${token}&reason=no_pending_user`,
+        `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=not_found`,
       );
     }
   } catch (dbError) {
     logError(`Database error finding pending user: ${dbError.message}`);
     return res.redirect(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=system_error`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=error`,
     );
   }
 
@@ -111,7 +111,7 @@ export const signUp = async (req, res) => {
   } catch (dbError) {
     logError(`Database error checking existing user: ${dbError.message}`);
     return res.redirect(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=system_error`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=error`,
     );
   }
 
@@ -132,7 +132,7 @@ export const signUp = async (req, res) => {
   } catch (dbError) {
     logError(`Error creating user: ${dbError.message}`);
     return res.redirect(
-      `${baseDonnaVinoEcommerceWebUrl}/verification-failed?reason=system_error`,
+      `${baseDonnaVinoEcommerceWebUrl}/signup/verification-failed?type=error`,
     );
   }
 

--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -3,12 +3,14 @@ import { preSignUp } from "../controllers/authControllers/preSignUpController.js
 import { signUp } from "../controllers/authControllers/signupController.js";
 import { signInWithGoogleController } from "../controllers/authControllers/signInWithGoogleController.js";
 import { login } from "../controllers/authControllers/loginController.js";
+import { resendVerificationEmail } from "../controllers/authControllers/resendVerificationController.js";
 
 const authRouter = express.Router();
 
 authRouter.post("/pre-sign-up", preSignUp);
 authRouter.get("/sign-up", signUp);
 authRouter.post("/sign-in-with-google", signInWithGoogleController);
+authRouter.get("/resend-verification-email", resendVerificationEmail);
 authRouter.post("/log-in", login);
 
 export default authRouter;

--- a/src/services/email/verificationEmailService.js
+++ b/src/services/email/verificationEmailService.js
@@ -1,0 +1,33 @@
+import fs from "fs";
+import path from "path";
+import { sendEmail } from "../../util/emailUtils.js";
+import { generateToken } from "../token/tokenGenerator.js";
+import { baseApiUrl } from "../../config/environment.js";
+import { logError, logInfo } from "../../util/logging.js";
+
+export const sendVerificationEmail = async (user) => {
+  try {
+    const token = await generateToken(user.email);
+
+    const verifyUrl = `${baseApiUrl}/api/auth/sign-up?token=${token}`;
+
+    const templateName = user.isSubscribed
+      ? "verifyEmailForSignupWithNewsletterTemplate.html"
+      : "verifyEmailForSignupTemplate.html";
+
+    const templatePath = path.resolve(
+      process.cwd(),
+      `src/templates/${templateName}`,
+    );
+
+    let templateContent = fs.readFileSync(templatePath, "utf-8");
+    templateContent = templateContent.replace("{{VERIFY_URL}}", verifyUrl);
+
+    const verifySubject = "Verify your email address for Donna Vino";
+    await sendEmail(user.email, verifySubject, templateContent);
+    logInfo(`Verification email sent to ${user.email}`);
+  } catch (error) {
+    logError(`Error sending verification email: ${error.message}`);
+    throw error; // Re-throw to allow caller to handle the error
+  }
+};


### PR DESCRIPTION
# [FEATURE] Add Resend Verification Endpoint with Email Service and Refactoring Token Handling
## Description
This PR adds a new endpoint for resending verification emails to users who have started but not completed the signup process. To support this feature, I've extracted the email verification logic into a dedicated service and refactored the existing `preSignUp` controller to use this service. Additionally, I've improved the verification error flow in `signup` controller to automatically handle expired tokens.

## Changes Made

**New Endpoint:**
   - Added `/api/auth/resend-verification-email` endpoint that allows users to request a new verification email
   - Implemented `resendVerificationController.js` to handle these requests
   
**Service Extraction:**
   - Created `sendVerificationEmail` service in `services/email/verificationEmailService.js` to encapsulate email verification logic
   - Moved token generation, template selection, and email sending from controllers to the service
   
**Controller Refactoring:**
   - Refactored `preSignUpController` to use the new email verification service
   - Removed token generation and email template handling from controllers
  
**Improved Token Handling:**
   - Enhanced `signupController` to automatically resend verification emails when tokens are expired
   - Added functionality to extract information from expired tokens and generate new verification links
   - Modified redirections to include information about error type for better user experience

**Testing:**
- Added comprehensive test suite for the resend verification endpoint
- Updated tests for the preSignUp controller
- Added tests for the new email verification service
- Updated tests for the signUp controller

## Testing Steps
Manual Testing:
- Create a new pending user account via the `preSignUp` endpoint
- Use the resend verification endpoint with the same email to request a new verification email
- Verify that the email is sent and contains a working verification link
- Test edge cases (non-existent email, already verified user, etc.)
- Test expired token flow by:
   - Creating a new account and receiving a verification email
   - Waiting for the token to expire (configured for 2 minutes in test environment)
   - Clicking the expired verification link
   - Verifying that a new email is automatically sent

Example of logs:
<img width="500" alt="" src="https://github.com/user-attachments/assets/5c3b986c-95cf-46cf-9e8d-5e5c3f3cd9da" />


API Endpoints:
`GET /api/auth/resend-verification-email?email=user@example.com` - Resends verification email to the specified email
`POST /api/auth/pre-sign-up` - Creates a pending user (now using the same email service)
`GET /api/auth/sign-up?token=TOKEN` - Verifies user email and handles expired tokens automatically

## Issues Addressed
[Implement signup #88](https://github.com/Donna-Vino-Aps/donna-vino-ecommerce/issues/88)