### PR TITLE
[FIX] Make Email Login Case-insensitive

### DIFF
--- a/src/__tests__/controllers/authControllers/loginController.test.js
+++ b/src/__tests__/controllers/authControllers/loginController.test.js
@@ -138,4 +138,18 @@ describe("loginController", () => {
     expect(loginResponse.body.success).toBe(true);
     expect(loginResponse.body.msg).toBe("Login successful");
   });
+
+  test("Should login successfully with mixed-case email", async () => {
+    const userData = {
+      email: "JohnDoe@example.com",
+      password: "Password123!",
+    };
+
+    const response = await request
+      .post("/api/auth/log-in")
+      .send({ user: userData });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+  });
 });

--- a/src/__tests__/controllers/authControllers/loginController.test.js
+++ b/src/__tests__/controllers/authControllers/loginController.test.js
@@ -152,4 +152,18 @@ describe("loginController", () => {
     expect(response.status).toBe(200);
     expect(response.body.success).toBe(true);
   });
+
+  test("Should login successfully with uppercase email", async () => {
+    const userData = {
+      email: "JOHNDOE@EXAMPLE.COM",
+      password: "Password123!",
+    };
+
+    const response = await request
+      .post("/api/auth/log-in")
+      .send({ user: userData });
+
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+  });
 });

--- a/src/controllers/authControllers/loginController.js
+++ b/src/controllers/authControllers/loginController.js
@@ -27,7 +27,7 @@ export const login = async (req, res) => {
       return res.status(400).json({ success: false, error: errorMessage });
     }
 
-    const userFound = await User.findOne({ email });
+    const userFound = await User.findOne({ email: email.toLowerCase() });
 
     if (!userFound) {
       return res.status(401).json({


### PR DESCRIPTION
## [FIX] Make Email Login Case-insensitive

### Description
This PR fixes an issue where the login system was case-sensitive for email addresses. Users could fail to login if they used a different capitalization than what was stored in the database.

### Changes Made
- Modified `loginController.js` to convert email to lowercase before database query
- Added two test cases to verify case-insensitive login functionality

### Testing Steps
Try logging in with:
- Original registered email (e.g., `johndoe@example.com`)
- Mixed-case version (e.g., `JohnDoe@example.com`)
- All uppercase version (e.g., `JOHNDOE@EXAMPLE.COM`)
- Verify all variations return 200 status and successful login