### PR TITLE
[FEATURE] Improve data cleanup for signup decline process

### DIFF
--- a/src/controllers/register/emailVerification.js
+++ b/src/controllers/register/emailVerification.js
@@ -78,9 +78,11 @@ export async function confirm(req, res) {
  *
  * Steps:
  * - Validates the token using EmailVerificationToken.fromJWT()
- * - If invalid or expired, redirects to `/signUp/error`
- * - Deletes the token record (optional: you could also delete the `UserPre` record here)
- * - Redirects to `/signUp/canceled` on the frontend
+ * - Validates that the token email matches the provided email
+ * - If invalid or expired, redirects to `/signup/decline-error`
+ * - Deletes the UserPre record for this email
+ * - Deletes the token record
+ * - Redirects to `/signup/canceled` on the frontend
  *
  */
 export async function decline(req, res) {

--- a/src/controllers/register/emailVerification.js
+++ b/src/controllers/register/emailVerification.js
@@ -97,6 +97,8 @@ export async function decline(req, res) {
     return res.redirect(errorPageUrl);
   }
 
+  await UserPre.findOneAndDelete({ email });
+
   await emailToken.revoke();
 
   return res.redirect(`${process.env.FRONTEND_URI}/signUp/canceled`);

--- a/src/controllers/register/emailVerification.js
+++ b/src/controllers/register/emailVerification.js
@@ -84,11 +84,17 @@ export async function confirm(req, res) {
  *
  */
 export async function decline(req, res) {
+  const email = req.query.email;
   const token = req.query.token;
 
   const emailToken = await EmailVerificationToken.fromJWT(token);
   if (!emailToken) {
-    return res.redirect(`${process.env.FRONTEND_URI}/signUp/error`);
+    return res.redirect(errorPageUrl);
+  }
+
+  const decoded = jwt.decode(token);
+  if (decoded.email !== email) {
+    return res.redirect(errorPageUrl);
   }
 
   await emailToken.revoke();

--- a/src/controllers/register/emailVerification.js
+++ b/src/controllers/register/emailVerification.js
@@ -86,6 +86,8 @@ export async function confirm(req, res) {
 export async function decline(req, res) {
   const email = req.query.email;
   const token = req.query.token;
+  const frontedUrl = baseDonnaVinoEcommerceWebUrl;
+  const errorPageUrl = `${frontedUrl}/signup/decline-error`;
 
   const emailToken = await EmailVerificationToken.fromJWT(token);
   if (!emailToken) {
@@ -101,7 +103,8 @@ export async function decline(req, res) {
 
   await emailToken.revoke();
 
-  return res.redirect(`${process.env.FRONTEND_URI}/signUp/canceled`);
+  const url = new URL("/signup/canceled", frontedUrl);
+  return res.redirect(url.toString());
 }
 
 /**

--- a/src/views/email/emailConfirmation.hbs
+++ b/src/views/email/emailConfirmation.hbs
@@ -70,7 +70,7 @@
           >Verify email</a>
         </div>
         <p class="info">
-          (If you did not sign up for this account, you can ignore this email or
+          (If you did not sign up for this account, you can ignore this email or,<br />
           click
           <a
             href="{{baseUrl}}/api/register/email/decline?token={{token}}&email={{email}}"

--- a/src/views/email/emailConfirmation.hbs
+++ b/src/views/email/emailConfirmation.hbs
@@ -70,7 +70,8 @@
           >Verify email</a>
         </div>
         <p class="info">
-          (If you did not sign up for this account, you can ignore this email or,<br />
+          (If you did not sign up for this account, you can ignore this email
+          or,<br />
           click
           <a
             href="{{baseUrl}}/api/register/email/decline?token={{token}}&email={{email}}"


### PR DESCRIPTION
# [FEATURE] Improve data cleanup for signup decline process

## Description
This PR enhances the email confirmation decline functionality. Previously, the decline process only invalidated the token but left the ⁠UserPre record in the database for period of TTL. This update ensures that when a user declines the signup, their pre-registration data is completely removed. It also adds a validation step to ensure the email in the decline request matches the email in the token, improving security.

## Changes Made
- Updated ⁠GET `/api/register/email/decline`:
   - Now requires an ⁠email query parameter in addition to the ⁠token. 	
   - Redirects to a new specific error page (`⁠/signup/decline-error`) if the token's email does not match the provided ⁠email parameter. 
- The ⁠decline controller in `⁠src/controllers/register/emailVerification.js` now deletes the corresponding ⁠UserPre record from the database. 

## Testing Steps
1. Setup: no specific.

2. Steps:
- Register a new user through the signup form to trigger the confirmation email. 
- Check the received email and inspect the "click here" link to decline the registration. It should have the format: ⁠.../api/register/email/decline?token=<JWT>&email=<USER_EMAIL> 	
- Click the decline link.
- Test the error case: Manually change the ⁠email parameter in the URL to something different and attempt to visit the URL. 	

3. Expected Result:
- After clicking the correct link, you should be redirected to the `⁠/signup/canceled` page on the frontend. 
- The ⁠UserPre record for that email should be deleted from the database. 
- When testing the error case, you should be redirected to the `⁠/signup/decline-error` page, and the ⁠UserPre record should not be deleted.